### PR TITLE
changes to summaryIssue

### DIFF
--- a/components/admin/ScheduleManagement.tsx
+++ b/components/admin/ScheduleManagement.tsx
@@ -1179,7 +1179,7 @@ const Schedule = ({
                 </div>
 
                 <div>
-                  <Label className="text-right">Summary</Label>
+                  <Label className="text-right">Notes (Only viewable Admin Side)</Label> {/* admin only notes label */}
                   <Textarea
                     value={selectedSession?.summary}
                     onChange={(e) =>
@@ -1190,6 +1190,56 @@ const Schedule = ({
                     }
                   ></Textarea>
                 </div>
+
+                {(() => {
+                  const rawSef = (selectedSession as any)?.session_exit_form as
+                    | string
+                    | null
+                    | undefined; // pull sef string w null safe
+
+                  const sefFlags: string[] = []; // keep sef boxes tiny
+                  if ((selectedSession as any)?.isQuestionOrConcern)
+                    sefFlags.push("question/concern"); // show tutor box
+                  if ((selectedSession as any)?.isFirstSession)
+                    sefFlags.push("first session"); // show tutor box
+                  if (selectedSession.status === "Cancelled")
+                    sefFlags.push("cancelled"); // quick context
+
+                  let sefReasonText = rawSef ?? ""; // default to raw text
+                  if (rawSef && rawSef.trim().startsWith("{")) {
+                    try {
+                      const parsed = JSON.parse(rawSef) as any; // handle future sef json
+                      sefReasonText =
+                        parsed?.reason ??
+                        parsed?.notes ??
+                        parsed?.exitReason ??
+                        rawSef; // prefer explicit reason field
+                      const extraFlags =
+                        parsed?.boxes ?? parsed?.flags ?? parsed?.options; // try grab checkbox list
+                      if (Array.isArray(extraFlags)) {
+                        extraFlags
+                          .filter((x) => typeof x === "string")
+                          .forEach((x) => sefFlags.push(x)); // merge extra boxes
+                      }
+                    } catch {
+                      // ignore parse fail, raw text fine
+                    }
+                  }
+
+                  return (
+                    <div>
+                      <Label>SEF Exit Reason</Label> {/* show sef reason */}
+                      <Textarea
+                        readOnly
+                        value={sefReasonText || ""}
+                        placeholder="no session exit form yet"
+                      />
+                      <p className="text-xs text-gray-500 mt-1">
+                        SEF boxes: {sefFlags.length ? sefFlags.join(", ") : "none"}
+                      </p>
+                    </div>
+                  );
+                })()}
                 <div className="flex flex-col gap-3">
                   <Link
                     href={`/dashboard/session/${selectedSession.id}/participation`}


### PR DESCRIPTION
I added a read-only block inside the “session details” dialog in ScheduleManagement.tsx that surfaces selectedSession.session_exit_form in a new textarea labeled “sef exit reason”, so admins can actually see what the tutor typed. right under that textarea i added a tiny line that says and it stays compact by showing a comma-separated list of flags instead of a big grid of checkboxes. that flag list is built from the session booleans we already have isQuestionOrConcern -> question/concern, isFirstSession -> first session, plus cancelled if the status is cancelled, so it still reflects the tutor-side “checkbox style” info without taking up space. i also made it not brittle by checking if session_exit_form looks like json (starts with {), then trying JSON.parse and preferring fields like reason/notes/exitReason for the displayed text, and merging any array fields like boxes/flags/options into that same compact sef boxes list; if parsing fails it just falls back to showing the raw string so nothing breaks. lastly i changed the admin label “summary” to “notes (only viewable admin side)” but that’s just a label change, it still edits the same selectedSession.summary field.