### PR TITLE
weekly duplicate sessions

### DIFF
--- a/app/api/sessions/update-week/route.ts
+++ b/app/api/sessions/update-week/route.ts
@@ -81,6 +81,14 @@ async function addSessionsServer(
 
     //Set created to avoid duplicates
     const scheduledSessions: Set<string> = await getSessionKeys(sessions);
+
+    // skip enrollments that already have a session this week, even if rescheduled to a different time
+    const enrollmentsWithSessions: Set<string> = new Set(
+      sessions
+        .filter((s) => s.enrollmentId)
+        .map((s) => s.enrollmentId as string)
+    );
+
     // Prepare bulk insert data
     const sessionsToCreate: any[] = [];
 
@@ -101,6 +109,11 @@ async function addSessionsServer(
       const startDate_asDate = new Date(startDate); //UTC
 
       if (enrollment.paused) {
+        continue;
+      }
+
+      // already has a session this week, probably rescheduled
+      if (enrollmentsWithSessions.has(id)) {
         continue;
       }
 
@@ -204,8 +217,8 @@ async function addSessionsServer(
       }
     }
 
-    const sessions = await batchInsertSessions(sessionsToCreate);
-    return sessions ? sessions : [];
+    const createdSessions = await batchInsertSessions(sessionsToCreate);
+    return createdSessions ? createdSessions : [];
   } catch (error) {
     console.error("Error creating sessions:", error);
     throw error;
@@ -229,7 +242,7 @@ const batchInsertSessions = async (sessionsToCreate: Session[]) => {
 
       if (data) {
         // Transform returned data to Session objects
-        const sessions: Session[] = data.map((session: any) => ({
+        const transformedSessions: Session[] = data.map((session: any) => ({
           id: session.id,
           enrollmentId: session.enrollment_id,
           createdAt: session.created_at,
@@ -246,7 +259,7 @@ const batchInsertSessions = async (sessionsToCreate: Session[]) => {
           duration: session.duration,
         }));
 
-        return sessions;
+        return transformedSessions;
       }
     }
   } catch (error) {

--- a/lib/actions/session.actions.ts
+++ b/lib/actions/session.actions.ts
@@ -120,6 +120,14 @@ export async function addSessions(
 
     //Set created to avoid duplicates
     const scheduledSessions: Set<string> = await getSessionKeys(sessions);
+
+    // skip enrollments that already have a session this week, even if rescheduled to a different time
+    const enrollmentsWithSessions: Set<string> = new Set(
+      sessions
+        .filter((s) => s.enrollmentId)
+        .map((s) => s.enrollmentId as string)
+    );
+
     // Prepare bulk insert data
     const sessionsToCreate: any[] = [];
 
@@ -139,6 +147,11 @@ export async function addSessions(
 
       //Check if paused over the summer
       if (enrollment.paused) {
+        continue;
+      }
+
+      // already has a session this week, probably rescheduled
+      if (enrollmentsWithSessions.has(id)) {
         continue;
       }
 


### PR DESCRIPTION
prevents the weekly session generator from creating duplicate sessions when a session gets rescheduled to a different date. the generator now tracks which enrollments already have a session in the target week, regardless of what time it's at. if an enrollment already has one, it skips creating another. this stops the generator from recreating the original slot after a session moves.

also fixed variable shadowing in batchInsertSessions so the local sessions variable didn't shadow the parameter, which was causing type errors.

rescheduled sessions stay on their new date, and the generator won't duplicate them anymore. if users still have old duplicates sitting around from before this fix, those need manual db cleanup to mark them as cancelled.