### PR TITLE
fix enrollments auto refresh and remove function tester dead code

### DIFF
--- a/components/admin/EnrollmentsManagement.tsx
+++ b/components/admin/EnrollmentsManagement.tsx
@@ -109,12 +109,11 @@ const EnrollmentList = ({
   studentsPromise,
   tutorsPromise,
 }: any) => {
-  const combinedPromise = Promise.all([
-    enrollmentsPromise,
-    meetingsPromise,
-    studentsPromise,
-    tutorsPromise,
-  ]);
+  // stable ref so use() doesnt re-suspend on every render
+  const combinedPromise = useMemo(
+    () => Promise.all([enrollmentsPromise, meetingsPromise, studentsPromise, tutorsPromise]),
+    [enrollmentsPromise, meetingsPromise, studentsPromise, tutorsPromise],
+  );
   const [initialEnrollments, initialMeetings, initialStudents, initialTutors] =
     use(combinedPromise);
   const [enrollments, setEnrollments] =

--- a/components/admin/ScheduleManagement.tsx
+++ b/components/admin/ScheduleManagement.tsx
@@ -81,7 +81,6 @@ import { Textarea } from "../ui/textarea";
 import { boolean } from "zod";
 import { checkAvailableMeeting } from "@/lib/actions/meeting.actions";
 import { getAllActiveEnrollments } from "@/lib/actions/enrollment.actions";
-import { getEnrollmentsWithMissingSEF } from "@/lib/actions/enrollment.server.actions";
 import { useMutation, useQueries, useQuery } from "@tanstack/react-query";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -661,15 +660,7 @@ const Schedule = ({
     return { totalSessions, tutorsInvolved };
   };
 
-  const handleGetMissingSEF = async () => {
-    try {
-      await getEnrollmentsWithMissingSEF();
-      toast.success("Printed to console");
-    } catch (error) {
-      console.error(error);
-      toast.error("Please view Dev Console for error");
-    }
-  };
+
 
   return (
     <>
@@ -886,12 +877,6 @@ const Schedule = ({
               </ScrollArea>
             </DialogContent>
           </Dialog>
-          <Button
-            className="bg-connect-me-blue-4"
-            onClick={() => handleGetMissingSEF()}
-          >
-            Function Tester
-          </Button>
 
           {isLoading ? (
             <div className="text-center py-10">


### PR DESCRIPTION
fixed the enrollments page auto refresh bug where clicking any button on the page would cause the whole page to suspend and reload, making it impossible to add enrollments. the issue was that Promise.all() was being called on every render without memoization, so the use() hook would see a fresh promise every time state changed and re-suspend the component. wrapped it in useMemo now so the promise reference stays stable across renders.

also removed the leftover function tester dead code that was still hanging around in schedule management from the earlier calendar work. the handler, the button, and the import all got removed since that was supposed to be gone already but somehow missed. Removed now!

Closes #498 