### PR TITLE
fix production enrollment refresh: remove use() hook, await data in s…

### DIFF
--- a/app/(protected)/dashboard/(admin)/enrollments/page.tsx
+++ b/app/(protected)/dashboard/(admin)/enrollments/page.tsx
@@ -6,32 +6,20 @@ import { getAllProfiles } from "@/lib/actions/profile.server.actions";
 import { Suspense } from "react";
 
 async function MyEnrollmentsData() {
-  // const [enrollments, meetings, students, tutors] = await Promise.all([
-  //   getAllEnrollments(),
-  //   getMeetings(),
-  //   getAllProfiles("Student").then((s) =>
-  //     s ? s.filter((s) => s.status === "Active") : null
-  //   ),
-  //   getAllProfiles("Tutor").then((s) =>
-  //     s ? s.filter((s) => s.status === "Active") : null
-  //   ),
-  // ]);
-
-  const enrollments = getAllEnrollments();
-  const meetings = getMeetings();
-  const students = getAllProfiles("Student")
-  const tutors = getAllProfiles("Tutor")
+  // await data here so client component doesnt need use() which is unstable in react 18
+  const [enrollments, meetings, students, tutors] = await Promise.all([
+    getAllEnrollments(),
+    getMeetings(),
+    getAllProfiles("Student"),
+    getAllProfiles("Tutor"),
+  ]);
 
   return (
     <EnrollmentsManager
-      enrollmentsPromise={enrollments}
-      meetingsPromise={meetings}
-      studentsPromise={students}
-      tutorsPromise={tutors}
-      // initialEnrollments={enrollments}
-      // initialMeetings={meetings}
-      // initialStudents={students}
-      // initialTutors={tutors}
+      initialEnrollments={enrollments}
+      initialMeetings={meetings}
+      initialStudents={students}
+      initialTutors={tutors}
     />
   );
 }

--- a/components/admin/EnrollmentsManagement.tsx
+++ b/components/admin/EnrollmentsManagement.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect, useMemo, use } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import {
   AlarmClockMinus,
   MessageCircleIcon,
@@ -63,6 +63,7 @@ import {
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -104,18 +105,12 @@ const durationSchema = z.object({
 });
 
 const EnrollmentList = ({
-  enrollmentsPromise,
-  meetingsPromise,
-  studentsPromise,
-  tutorsPromise,
+  initialEnrollments,
+  initialMeetings,
+  initialStudents,
+  initialTutors,
 }: any) => {
-  // stable ref so use() doesnt re-suspend on every render
-  const combinedPromise = useMemo(
-    () => Promise.all([enrollmentsPromise, meetingsPromise, studentsPromise, tutorsPromise]),
-    [enrollmentsPromise, meetingsPromise, studentsPromise, tutorsPromise],
-  );
-  const [initialEnrollments, initialMeetings, initialStudents, initialTutors] =
-    use(combinedPromise);
+  // data is awaited in server component now, no use() needed
   const [enrollments, setEnrollments] =
     useState<Enrollment[]>(initialEnrollments);
   const [filteredEnrollments, setFilteredEnrollments] =
@@ -642,6 +637,7 @@ const EnrollmentList = ({
                 <DialogContent className="sm:max-w-[500px]">
                   <DialogHeader>
                     <DialogTitle>Add New Enrollment</DialogTitle>
+                    <DialogDescription className="sr-only">add a new enrollment</DialogDescription>
                   </DialogHeader>
                   <ScrollArea className="max-h-[calc(80vh-120px)] pr-4">
                     {" "}
@@ -1177,6 +1173,7 @@ const EnrollmentList = ({
         <DialogContent className="sm:max-w-[500px]">
           <DialogHeader>
             <DialogTitle>Edit Enrollment</DialogTitle>
+            <DialogDescription className="sr-only">edit enrollment details</DialogDescription>
           </DialogHeader>
           <ScrollArea className="max-h-[calc(80vh-120px)] pr-4">
             {" "}
@@ -1497,6 +1494,7 @@ const EnrollmentList = ({
         <DialogContent className="sm:max-w-[500px]">
           <DialogHeader>
             <DialogTitle>Delete Enrollment</DialogTitle>
+            <DialogDescription className="sr-only">confirm enrollment deletion</DialogDescription>
           </DialogHeader>
           <div className="py-4">
             <p>


### PR DESCRIPTION
fix production enrollments refresh bug caused by react 18 use() hook instability

on production, clicking any button on the enrollments page would cause the entire page to refresh and lose state, making it impossible to add enrollments with 747+ records. on localhost it worked fine because promises resolved instantly.

root cause: use() hook is experimental in react 18 (only stabilized in react 19). on each re-render triggered by dialog/button clicks, react 18 would re-suspend the use() promises, kill the suspense boundary, unmount the entire component losing all state, then remount fresh.

what i did:
- moved promise.all() to server component instead of passing raw promises to client
- data is now awaited in the server before being passed down
- removed use() hook entirely, component now accepts initialEnrollments as props
- added missing DialogDescription to all 3 dialogs to suppress radix aria warnings
- #503 
