### PR TITLE
Search lookup

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -88,18 +88,3 @@
     @apply bg-background text-foreground;
   }
 }
-
-@media (min-width: 1280px) {
-  .app-scale-shell {
-    zoom: var(--app-scale-factor);
-  }
-
-  @supports not (zoom: 1) {
-    .app-scale-shell {
-      min-height: calc(100vh / var(--app-scale-factor));
-      transform: scale(var(--app-scale-factor));
-      transform-origin: top left;
-      width: calc(100% / var(--app-scale-factor));
-    }
-  }
-}

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,6 +7,7 @@
     --clr-gray-light: rgb(249, 248, 248);
     --clr-gray-base: rgb(218, 218, 218);
     --clr-gray-dark: rgb(114, 110, 110);
+    --app-scale-factor: 0.9;
 
     --background: 0 0% 100%;
     --foreground: 0 0% 3.9%;
@@ -85,5 +86,20 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@media (min-width: 1280px) {
+  .app-scale-shell {
+    zoom: var(--app-scale-factor);
+  }
+
+  @supports not (zoom: 1) {
+    .app-scale-shell {
+      min-height: calc(100vh / var(--app-scale-factor));
+      transform: scale(var(--app-scale-factor));
+      transform-origin: top left;
+      width: calc(100% / var(--app-scale-factor));
+    }
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,9 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <PostHogProvider>
-          {children}
+          <div className="app-scale-shell">
+            {children}
+          </div>
           {/* <SpeedInsights /> */}
         </PostHogProvider>
       </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,9 +22,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <PostHogProvider>
-          <div className="app-scale-shell">
-            {children}
-          </div>
+          {children}
           {/* <SpeedInsights /> */}
         </PostHogProvider>
       </body>

--- a/components/admin/ScheduleManagement.tsx
+++ b/components/admin/ScheduleManagement.tsx
@@ -70,7 +70,6 @@ import {
   // checkMeetingsAvailability,
   // isMeetingAvailable,
 } from "@/lib/actions/admin.actions";
-// Add these imports at the top of the file
 import { addOneSession } from "@/lib/actions/session.server.actions";
 import { addHours, areIntervalsOverlapping } from "date-fns";
 
@@ -105,14 +104,19 @@ const Schedule = ({
   initialTutors,
   initialMeetings,
 }: any) => {
-  // changed to use useQueryCLient so cache invalidation actually propogates
   const queryClient = useQueryClient();
   const [currentWeek, setCurrentWeek] = useState(new Date());
-  const [calendarView, setCalendarView] = useState<"day" | "week" | "month">("week"); // day, week, month toggle
-  const [selectedDay, setSelectedDay] = useState(new Date()); // for day view nav
+  const [calendarView, setCalendarView] = useState<"day" | "week" | "month">("week");
+  const [selectedDay, setSelectedDay] = useState(new Date());
+
+  // keep currentWeek in sync when day view crosses week boundary
+  useEffect(() => {
+    if (calendarView === "day") setCurrentWeek(selectedDay);
+  }, [selectedDay, calendarView]);
+
   const weekEnd = endOfWeek(currentWeek).toISOString();
   const weekStart = startOfWeek(currentWeek).toISOString();
-  // query range adapts to view so month view fetches all its sessions
+  // adapts fetch range to whichever view is active
   const queryStart = calendarView === "month" ? startOfWeek(startOfMonth(currentWeek)).toISOString() : weekStart;
   const queryEnd = calendarView === "month" ? endOfWeek(endOfMonth(currentWeek)).toISOString() : weekEnd;
   // const [enrollments, setEnrollments] = useState<Enrollment[]>([]);
@@ -123,8 +127,6 @@ const Schedule = ({
   const [selectedSession, setSelectedSession] = useState<Session | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  //-----Checking Meeting Availability-----
-
   const [isCheckingMeetingAvailability, setIsCheckingMeetingAvailability] =
     useState(false);
   const [meetingAvailabilityMap, setMeetingAvailabilityMap] = useState<
@@ -132,7 +134,6 @@ const Schedule = ({
   >({});
   const [allSessions, setAllSessions] = useState<Session[]>([]);
 
-  //---------------------------------
   const initialMount = useRef(true);
   const [openStudentOptions, setOpenStudentOptions] = useState(false);
   const [openTutorOptions, setOpentTutorOptions] = useState(false);
@@ -215,7 +216,17 @@ const Schedule = ({
     queries: [
       {
         queryKey: ["sessions", queryStart, queryEnd],
-        queryFn: () => getAllSessions(queryStart, queryEnd, "date", true),
+        queryFn: async () => {
+          // weekly chunks to avoid supabase 1000 row cap
+          const fetches: Promise<Session[]>[] = [];
+          let cursor = startOfWeek(new Date(queryStart));
+          const end = new Date(queryEnd);
+          while (cursor <= end) {
+            fetches.push(getAllSessions(cursor.toISOString(), endOfWeek(cursor).toISOString(), "date", true));
+            cursor = addWeeks(cursor, 1);
+          }
+          return (await Promise.all(fetches)).flat();
+        },
       },
       {
         queryKey: ["students"],
@@ -224,10 +235,6 @@ const Schedule = ({
       {
         queryKey: ["tutors"],
         queryFn: () => getAllProfiles("Tutor"),
-      },
-      {
-        queryKey: ["enrollments", weekEnd],
-        queryFn: () => getAllActiveEnrollments(weekEnd),
       },
       {
         queryKey: ["meetings"],
@@ -240,23 +247,13 @@ const Schedule = ({
     sessionsResult,
     studentsResult,
     tutorsResult,
-    enrollmentsResult,
     meetingsResult,
   ] = query;
 
   const sessions = sessionsResult.data || [];
   const students = studentsResult.data || [];
   const tutors = tutorsResult.data || [];
-  const enrollments: Enrollment[] = useMemo(
-    () => enrollmentsResult.data ?? [],
-    [enrollmentsResult.data],
-  );
   const meetings = meetingsResult.data || [];
-  // added enrollment filtering,
-  const activeEnrollmentIds = useMemo(
-    () => new Set(enrollments.map((enrollment: Enrollment) => enrollment.id)),
-    [enrollments],
-  );
 
   let isLoading = sessionsResult.isLoading;
 
@@ -504,7 +501,7 @@ const Schedule = ({
     },
     onSettled: () => {},
   });
-  // refetch all of it before Update Week so new sessions arent created for deleted enrollments
+  // refetch enrollments first so deleted ones dont spawn sessions
   const handleUpdateWeek = async () => {
     const freshEnrollments =
       (await queryClient.fetchQuery({
@@ -515,20 +512,19 @@ const Schedule = ({
     updateWeekMutation.mutate({ enrollments: freshEnrollments });
   };
 
-  // pre-group sessions by day for perf, avoids filtering per cell
+  // groups sessions by day key so cells just do a map lookup
   const sessionsByDay = useMemo(() => {
     const map = new Map<string, Session[]>();
     for (const session of sessions) {
       if (!session?.date) continue;
       try {
-        if (!enrollmentsResult.isLoading && session.enrollmentId && !activeEnrollmentIds.has(session.enrollmentId)) continue;
         const dayKey = format(toZonedTime(parseISO(session.date), "America/New_York"), "yyyy-MM-dd");
         if (!map.has(dayKey)) map.set(dayKey, []);
         map.get(dayKey)!.push(session);
       } catch {}
     }
     return map;
-  }, [sessions, enrollmentsResult.isLoading, activeEnrollmentIds]);
+  }, [sessions]);
 
   const getValidSessionsForDay = (day: Date) => sessionsByDay.get(format(day, "yyyy-MM-dd")) || [];
 
@@ -607,25 +603,18 @@ const Schedule = ({
     setNewSession((prev) => {
       if (!prev) return {} as Session;
 
-      // Create a copy of the previous state
       const updated = { ...prev };
 
       if (name.includes(".")) {
         const [parent, child] = name.split(".");
-
-        // Type guard to ensure parent is a valid key of Session
         if (parent === "student" || parent === "tutor") {
-          // Ensure parent object exists
           const parentObj = (updated[parent] || {}) as Profile;
-
-          // Update the nested property
           updated[parent] = {
             ...parentObj,
             [child]: value,
           };
         }
       } else {
-        // Type guard to ensure name is a valid key of Session
         if (name in updated) {
           (updated as any)[name] = value;
         }
@@ -640,7 +629,6 @@ const Schedule = ({
     end: endOfWeek(currentWeek),
   });
 
-  // nav for all three views
   const goToPrevious = () => {
     if (calendarView === "day") setSelectedDay((d) => subDays(d, 1));
     else if (calendarView === "week") setCurrentWeek((w) => subWeeks(w, 1));
@@ -651,16 +639,14 @@ const Schedule = ({
     else if (calendarView === "week") setCurrentWeek((w) => addWeeks(w, 1));
     else setCurrentWeek((w) => addMonths(w, 1));
   };
-  const goToToday = () => {
-    const today = new Date();
-    setCurrentWeek(today);
-    setSelectedDay(today);
+  // jumps to a specific date, view aware
+  const goToDate = (date: Date) => {
+    setCurrentWeek(date);
+    setSelectedDay(date);
   };
 
-  // hours for the time grid, 7am to 10pm
   const HOURS = Array.from({ length: 16 }, (_, i) => i + 7);
 
-  // figure out which hour row a session falls into
   const getSessionHour = (dateStr: string) => {
     const d = toZonedTime(parseISO(dateStr), "America/New_York");
     return d.getHours();
@@ -670,14 +656,12 @@ const Schedule = ({
     return d.getMinutes();
   };
 
-  // month view helpers
   const monthStart = startOfMonth(currentWeek);
   const monthEnd = endOfMonth(currentWeek);
   const monthCalendarStart = startOfWeek(monthStart);
   const monthCalendarEnd = endOfWeek(monthEnd);
   const monthDays = eachDayOfInterval({ start: monthCalendarStart, end: monthCalendarEnd });
 
-  // memoized stats so we don't recompute every render
   const sessionStats = useMemo(() => ({
     totalSessions: sessions.length,
     tutorsInvolved: new Set(sessions.map((s) => s?.tutor?.id)).size,
@@ -685,7 +669,6 @@ const Schedule = ({
     totalStudents: students.length,
   }), [sessions, students]);
 
-  // session card used in all views
   const SessionCard = ({ session }: { session: Session }) => (
     <div
       onClick={() => {
@@ -713,7 +696,6 @@ const Schedule = ({
     </div>
   );
 
-  // header text for current view
   const getHeaderText = () => {
     if (calendarView === "day") return format(selectedDay, "EEEE, MMMM d, yyyy");
     if (calendarView === "month") return format(currentWeek, "MMMM yyyy");
@@ -724,14 +706,28 @@ const Schedule = ({
     <>
       <Toaster />
       <div className="p-6 bg-gray-50 min-h-screen">
-        {/* top bar */}
         <div className="bg-white rounded-xl shadow-sm p-4 mb-4">
           <div className="flex items-center justify-between flex-wrap gap-3">
-            {/* left side: nav */}
             <div className="flex items-center gap-2">
-              <Button variant="outline" size="sm" onClick={goToToday}>
-                Today
-              </Button>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button variant="outline" size="sm">
+                    Today
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-3" align="start">
+                  <div className="flex flex-col gap-2">
+                    <Button variant="ghost" size="sm" onClick={() => goToDate(new Date())}>Go to today</Button>
+                    <Input
+                      type="date"
+                      onChange={(e) => {
+                        const d = new Date(e.target.value + "T12:00:00");
+                        if (isValid(d)) goToDate(d);
+                      }}
+                    />
+                  </div>
+                </PopoverContent>
+              </Popover>
               <Button variant="ghost" size="icon" onClick={goToPrevious}>
                 <ChevronLeft className="h-4 w-4" />
               </Button>
@@ -743,9 +739,7 @@ const Schedule = ({
               </h2>
             </div>
 
-            {/* right side: view toggle and actions */}
             <div className="flex items-center gap-2">
-              {/* view toggle */}
               <div className="flex bg-gray-100 rounded-lg p-0.5">
                 {(["day", "week", "month"] as const).map((view) => (
                   <button
@@ -912,7 +906,6 @@ const Schedule = ({
             </div>
           </div>
 
-          {/* stats bar */}
           <div className="flex items-center gap-6 mt-3 pt-3 border-t text-sm text-gray-500">
             <span>
               <span className="font-medium text-gray-700">{sessionStats.totalSessions}</span> sessions
@@ -926,7 +919,6 @@ const Schedule = ({
           </div>
         </div>
 
-        {/* loading state */}
         {isLoading ? (
           <div className="bg-white rounded-xl shadow-sm p-10">
             <div className="text-center">
@@ -936,12 +928,10 @@ const Schedule = ({
           </div>
         ) : (
           <>
-            {/* week view, the main google calendar style grid */}
             {calendarView === "week" && (
               <div className="bg-white rounded-xl shadow-sm overflow-hidden">
-                {/* day headers */}
                 <div className="grid grid-cols-[60px_repeat(7,1fr)] border-b">
-                  <div className="border-r" /> {/* spacer for time col */}
+                  <div className="border-r" />
                   {weekDays.map((day) => (
                     <div
                       key={day.toISOString()}
@@ -963,7 +953,6 @@ const Schedule = ({
                   ))}
                 </div>
 
-                {/* time grid - no scroll, all sessions visible */}
                 <div className="grid grid-cols-[60px_repeat(7,1fr)]">
                   {HOURS.map((hour) => (
                     <React.Fragment key={hour}>
@@ -996,11 +985,9 @@ const Schedule = ({
               </div>
             )}
 
-            {/* day view */}
             {calendarView === "day" && (
               <div className="bg-white rounded-xl shadow-sm overflow-hidden">
                 <div className="grid grid-cols-[60px_1fr]">
-                  {/* header */}
                   <div className="border-r border-b" />
                   <div className={cn("py-3 px-4 border-b", isToday(selectedDay) && "bg-blue-50")}>
                     <p className="text-xs text-gray-500 uppercase">{format(selectedDay, "EEEE")}</p>
@@ -1036,10 +1023,8 @@ const Schedule = ({
               </div>
             )}
 
-            {/* month view */}
             {calendarView === "month" && (
               <div className="bg-white rounded-xl shadow-sm overflow-hidden">
-                {/* day of week headers */}
                 <div className="grid grid-cols-7 border-b">
                   {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((d) => (
                     <div key={d} className="text-center py-2 text-xs font-medium text-gray-500 uppercase border-r last:border-r-0">
@@ -1047,7 +1032,6 @@ const Schedule = ({
                     </div>
                   ))}
                 </div>
-                {/* calendar grid */}
                 <div className="grid grid-cols-7">
                   {monthDays.map((day) => {
                     const daySessions = getValidSessionsForDay(day);
@@ -1098,7 +1082,6 @@ const Schedule = ({
           </>
         )}
 
-        {/* session details modal, keeping all existing fields */}
         <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
           <DialogContent>
             <DialogHeader>

--- a/components/admin/ScheduleManagement.tsx
+++ b/components/admin/ScheduleManagement.tsx
@@ -745,7 +745,7 @@ const Schedule = ({
       <div className="p-6 bg-gray-50 min-h-screen">
         <div className="bg-white rounded-xl shadow-sm p-4 mb-4">
           <div className="flex items-center justify-between flex-wrap gap-3">
-            <div className="flex items-center gap-2">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
               <Popover>
                 <PopoverTrigger asChild>
                   <Button variant="outline" size="sm">
@@ -771,12 +771,12 @@ const Schedule = ({
               <Button variant="ghost" size="icon" onClick={goToNext}>
                 <ChevronRight className="h-4 w-4" />
               </Button>
-              <h2 className="text-lg font-semibold text-gray-800 ml-2">
+              <h2 className="ml-2 min-w-0 text-base font-semibold text-gray-800 sm:text-lg">
                 {getHeaderText()}
               </h2>
             </div>
 
-            <div className="flex items-center gap-2">
+            <div className="flex w-full flex-wrap items-center gap-2 md:w-auto md:justify-end">
               <div className="flex bg-gray-100 rounded-lg p-0.5">
                 {(["day", "week", "month"] as const).map((view) => (
                   <button
@@ -986,58 +986,61 @@ const Schedule = ({
         ) : (
           <>
             {calendarView === "week" && (
-              <div className="bg-white rounded-xl shadow-sm overflow-hidden">
-                <div className="grid grid-cols-[60px_repeat(7,1fr)] border-b">
-                  <div className="border-r" />
-                  {weekDays.map((day) => (
-                    <div
-                      key={day.toISOString()}
-                      className={cn(
-                        "text-center py-3 border-r last:border-r-0",
-                        isToday(day) && "bg-blue-50"
-                      )}
-                    >
-                      <p className="text-xs text-gray-500 uppercase">{format(day, "EEE")}</p>
-                      <p className={cn(
-                        "text-lg font-semibold",
-                        isToday(day)
-                          ? "bg-blue-600 text-white rounded-full w-8 h-8 flex items-center justify-center mx-auto"
-                          : "text-gray-800"
-                      )}>
-                        {format(day, "d")}
-                      </p>
-                    </div>
-                  ))}
-                </div>
-
-                <div className="grid grid-cols-[60px_repeat(7,1fr)]">
-                  {HOURS.map((hour) => (
-                    <React.Fragment key={hour}>
-                      <div className="border-r border-b min-h-[36px] flex items-start justify-end pr-2 pt-1">
-                        <span className="text-[11px] text-gray-400">
-                          {hour === 0 ? "12:00 AM" : hour < 12 ? `${hour}:00 AM` : hour === 12 ? "12:00 PM" : `${hour - 12}:00 PM`}
-                        </span>
+              <div className="overflow-x-auto rounded-xl bg-white shadow-sm">
+                <div className="min-w-[960px] overflow-hidden rounded-xl">
+                  <div className="grid grid-cols-[56px_repeat(7,minmax(128px,1fr))] border-b">
+                    <div className="border-r" />
+                    {weekDays.map((day) => (
+                      <div
+                        key={day.toISOString()}
+                        className={cn(
+                          "min-w-0 border-r py-3 text-center last:border-r-0",
+                          isToday(day) && "bg-blue-50"
+                        )}
+                      >
+                        <p className="text-xs uppercase text-gray-500">{format(day, "EEE")}</p>
+                        <p className={cn(
+                          "mx-auto flex h-8 w-8 items-center justify-center rounded-full text-lg font-semibold",
+                          isToday(day)
+                            ? "bg-blue-600 text-white"
+                            : "text-gray-800"
+                        )}>
+                          {format(day, "d")}
+                        </p>
                       </div>
-                      {weekDays.map((day) => {
-                        const daySessions = getValidSessionsForDay(day).filter(
-                          (s) => getSessionHour(s.date) === hour
-                        );
-                        return (
-                          <div
-                            key={`${day.toISOString()}-${hour}`}
-                            className={cn(
-                              "border-r border-b last:border-r-0 min-h-[36px] p-[2px] space-y-0.5",
-                              isToday(day) && "bg-blue-50/30"
-                            )}
-                          >
-                            {daySessions.map((session) => (
-                              <SessionCard key={session.id} session={session} />
-                            ))}
-                          </div>
-                        );
-                      })}
-                    </React.Fragment>
-                  ))}
+                    ))}
+                  </div>
+
+                  <div className="grid grid-cols-[56px_repeat(7,minmax(128px,1fr))]">
+                    {HOURS.map((hour) => (
+                      <React.Fragment key={hour}>
+                        <div className="flex min-h-[36px] items-start justify-end border-r border-b pr-2 pt-1">
+                          <span className="text-[11px] text-gray-400">
+                            {hour === 0 ? "12:00 AM" : hour < 12 ? `${hour}:00 AM` : hour === 12 ? "12:00 PM" : `${hour - 12}:00 PM`}
+                          </span>
+                        </div>
+                        {weekDays.map((day) => {
+                          const daySessions = getValidSessionsForDay(day).filter(
+                            (s) => getSessionHour(s.date) === hour
+                          );
+                          return (
+                            <div
+                              key={`${day.toISOString()}-${hour}`}
+                              className={cn(
+                                "min-w-0 space-y-0.5 border-r border-b p-[2px] last:border-r-0",
+                                "min-h-[36px]",
+                                isToday(day) && "bg-blue-50/30"
+                              )}
+                            >
+                              {daySessions.map((session) => (
+                                <SessionCard key={session.id} session={session} />
+                              ))}
+                            </div>
+                          );
+                        })}
+                      </React.Fragment>
+                    ))}
+                  </div>
                 </div>
               </div>
             )}
@@ -1081,58 +1084,60 @@ const Schedule = ({
             )}
 
             {calendarView === "month" && (
-              <div className="bg-white rounded-xl shadow-sm overflow-hidden">
-                <div className="grid grid-cols-7 border-b">
-                  {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((d) => (
-                    <div key={d} className="text-center py-2 text-xs font-medium text-gray-500 uppercase border-r last:border-r-0">
-                      {d}
-                    </div>
-                  ))}
-                </div>
-                <div className="grid grid-cols-7">
-                  {monthDays.map((day) => {
-                    const daySessions = getValidSessionsForDay(day);
-                    return (
-                      <div
-                        key={day.toISOString()}
-                        className={cn(
-                          "border-r border-b last:border-r-0 min-h-[100px] p-1",
-                          !isSameMonth(day, currentWeek) && "bg-gray-50 opacity-50",
-                          isToday(day) && "bg-blue-50"
-                        )}
-                      >
-                        <p className={cn(
-                          "text-xs font-medium mb-1",
-                          isToday(day)
-                            ? "bg-blue-600 text-white rounded-full w-5 h-5 flex items-center justify-center"
-                            : "text-gray-600"
-                        )}>
-                          {format(day, "d")}
-                        </p>
-                        <div className="space-y-0.5">
-                          {daySessions.map((session) => (
-                            <div
-                              key={session.id}
-                              onClick={() => {
-                                setSelectedSession(session);
-                                setIsModalOpen(true);
-                              }}
-                              className={cn(
-                                "text-[10px] px-1 py-0.5 rounded truncate cursor-pointer",
-                                session.status === "Complete"
-                                  ? "bg-green-100 text-green-800"
-                                  : session.status === "Cancelled"
-                                    ? "bg-red-100 text-red-800"
-                                    : "bg-blue-100 text-blue-800"
-                              )}
-                            >
-                              {session.tutor?.firstName} / {session.student?.firstName}
-                            </div>
-                          ))}
-                        </div>
+              <div className="overflow-x-auto rounded-xl bg-white shadow-sm">
+                <div className="min-w-[960px] overflow-hidden rounded-xl">
+                  <div className="grid grid-cols-7 border-b">
+                    {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((d) => (
+                      <div key={d} className="border-r py-2 text-center text-xs font-medium uppercase text-gray-500 last:border-r-0">
+                        {d}
                       </div>
-                    );
-                  })}
+                    ))}
+                  </div>
+                  <div className="grid grid-cols-7">
+                    {monthDays.map((day) => {
+                      const daySessions = getValidSessionsForDay(day);
+                      return (
+                        <div
+                          key={day.toISOString()}
+                          className={cn(
+                            "min-h-[100px] min-w-0 border-r border-b p-1 last:border-r-0",
+                            !isSameMonth(day, currentWeek) && "bg-gray-50 opacity-50",
+                            isToday(day) && "bg-blue-50"
+                          )}
+                        >
+                          <p className={cn(
+                            "mb-1 flex h-5 w-5 items-center justify-center rounded-full text-xs font-medium",
+                            isToday(day)
+                              ? "bg-blue-600 text-white"
+                              : "text-gray-600"
+                          )}>
+                            {format(day, "d")}
+                          </p>
+                          <div className="space-y-0.5">
+                            {daySessions.map((session) => (
+                              <div
+                                key={session.id}
+                                onClick={() => {
+                                  setSelectedSession(session);
+                                  setIsModalOpen(true);
+                                }}
+                                className={cn(
+                                  "cursor-pointer truncate rounded px-1 py-0.5 text-[10px]",
+                                  session.status === "Complete"
+                                    ? "bg-green-100 text-green-800"
+                                    : session.status === "Cancelled"
+                                      ? "bg-red-100 text-red-800"
+                                      : "bg-blue-100 text-blue-800"
+                                )}
+                              >
+                                {session.tutor?.firstName} / {session.student?.firstName}
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
                 </div>
               </div>
             )}

--- a/components/admin/ScheduleManagement.tsx
+++ b/components/admin/ScheduleManagement.tsx
@@ -58,7 +58,7 @@ import {
 } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Circle, Loader2, ChevronDown, Check } from "lucide-react";
+import { Circle, Loader2, ChevronDown, Check, Search, X } from "lucide-react";
 import {
   getAllSessions,
   updateSession,
@@ -126,6 +126,7 @@ const Schedule = ({
   const [loading, setLoading] = useState(false);
   const [selectedSession, setSelectedSession] = useState<Session | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
 
   const [isCheckingMeetingAvailability, setIsCheckingMeetingAvailability] =
     useState(false);
@@ -512,10 +513,46 @@ const Schedule = ({
     updateWeekMutation.mutate({ enrollments: freshEnrollments });
   };
 
-  // groups sessions by day key so cells just do a map lookup
+  const filteredSessions = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+
+    if (!q) {
+      return sessions;
+    }
+
+    return sessions.filter((session) => {
+      const tutorFirst = session.tutor?.firstName?.toLowerCase() ?? "";
+      const tutorLast = session.tutor?.lastName?.toLowerCase() ?? "";
+      const tutorEmail = session.tutor?.email?.toLowerCase() ?? "";
+
+      const studentFirst = session.student?.firstName?.toLowerCase() ?? "";
+      const studentLast = session.student?.lastName?.toLowerCase() ?? "";
+      const studentEmail = session.student?.email?.toLowerCase() ?? "";
+
+      const fields = [
+        tutorFirst,
+        tutorLast,
+        `${tutorFirst} ${tutorLast}`,
+        tutorEmail,
+        studentFirst,
+        studentLast,
+        `${studentFirst} ${studentLast}`,
+        studentEmail,
+      ];
+
+      for (const field of fields) {
+        if (field.includes(q)) {
+          return true;
+        }
+      }
+
+      return false;
+    });
+  }, [sessions, searchQuery]);
+
   const sessionsByDay = useMemo(() => {
     const map = new Map<string, Session[]>();
-    for (const session of sessions) {
+    for (const session of filteredSessions) {
       if (!session?.date) continue;
       try {
         const dayKey = format(toZonedTime(parseISO(session.date), "America/New_York"), "yyyy-MM-dd");
@@ -524,7 +561,7 @@ const Schedule = ({
       } catch {}
     }
     return map;
-  }, [sessions]);
+  }, [filteredSessions]);
 
   const getValidSessionsForDay = (day: Date) => sessionsByDay.get(format(day, "yyyy-MM-dd")) || [];
 
@@ -663,11 +700,11 @@ const Schedule = ({
   const monthDays = eachDayOfInterval({ start: monthCalendarStart, end: monthCalendarEnd });
 
   const sessionStats = useMemo(() => ({
-    totalSessions: sessions.length,
-    tutorsInvolved: new Set(sessions.map((s) => s?.tutor?.id)).size,
-    studentsThisWeek: new Set(sessions.map((s) => s?.student?.id)).size,
+    totalSessions: filteredSessions.length,
+    tutorsInvolved: new Set(filteredSessions.map((s) => s?.tutor?.id)).size,
+    studentsThisWeek: new Set(filteredSessions.map((s) => s?.student?.id)).size,
     totalStudents: students.length,
-  }), [sessions, students]);
+  }), [filteredSessions, students]);
 
   const SessionCard = ({ session }: { session: Session }) => (
     <div
@@ -906,16 +943,36 @@ const Schedule = ({
             </div>
           </div>
 
-          <div className="flex items-center gap-6 mt-3 pt-3 border-t text-sm text-gray-500">
-            <span>
-              <span className="font-medium text-gray-700">{sessionStats.totalSessions}</span> sessions
-            </span>
-            <span>
-              <span className="font-medium text-gray-700">{sessionStats.tutorsInvolved}</span> tutors
-            </span>
-            <span>
-              <span className="font-medium text-gray-700">{sessionStats.studentsThisWeek}</span> / {sessionStats.totalStudents} students
-            </span>
+          <div className="flex items-center gap-3 mt-3 pt-3 border-t">
+            <div className="relative flex-1 max-w-sm">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <Input
+                placeholder="Search tutor, student, or email..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-9 pr-8 h-8 text-sm"
+              />
+              {searchQuery && (
+                <button
+                  onClick={() => setSearchQuery("")}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              )}
+            </div>
+
+            <div className="flex items-center gap-6 text-sm text-gray-500">
+              <span>
+                <span className="font-medium text-gray-700">{sessionStats.totalSessions}</span> sessions
+              </span>
+              <span>
+                <span className="font-medium text-gray-700">{sessionStats.tutorsInvolved}</span> tutors
+              </span>
+              <span>
+                <span className="font-medium text-gray-700">{sessionStats.studentsThisWeek}</span> / {sessionStats.totalStudents} students
+              </span>
+            </div>
           </div>
         </div>
 

--- a/components/admin/ScheduleManagement.tsx
+++ b/components/admin/ScheduleManagement.tsx
@@ -5,18 +5,29 @@ import {
   format,
   startOfWeek,
   endOfWeek,
+  startOfMonth,
+  endOfMonth,
   eachDayOfInterval,
   addWeeks,
   subWeeks,
+  addDays,
+  subDays,
+  addMonths,
+  subMonths,
   parseISO,
   isAfter,
+  isSameDay,
+  isSameMonth,
+  isToday,
   isValid,
   previousDay,
+  getDay,
 } from "date-fns";
 import { toZonedTime } from "date-fns-tz";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import ProfileSelector from "@/components/ui/profile-selector";
 import {
   Command,
@@ -81,7 +92,6 @@ import { Textarea } from "../ui/textarea";
 import { boolean } from "zod";
 import { checkAvailableMeeting } from "@/lib/actions/meeting.actions";
 import { getAllActiveEnrollments } from "@/lib/actions/enrollment.actions";
-import { getEnrollmentsWithMissingSEF } from "@/lib/actions/enrollment.server.actions";
 import { useMutation, useQueries, useQuery } from "@tanstack/react-query";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -98,8 +108,13 @@ const Schedule = ({
   // changed to use useQueryCLient so cache invalidation actually propogates
   const queryClient = useQueryClient();
   const [currentWeek, setCurrentWeek] = useState(new Date());
+  const [calendarView, setCalendarView] = useState<"day" | "week" | "month">("week"); // day, week, month toggle
+  const [selectedDay, setSelectedDay] = useState(new Date()); // for day view nav
   const weekEnd = endOfWeek(currentWeek).toISOString();
   const weekStart = startOfWeek(currentWeek).toISOString();
+  // query range adapts to view so month view fetches all its sessions
+  const queryStart = calendarView === "month" ? startOfWeek(startOfMonth(currentWeek)).toISOString() : weekStart;
+  const queryEnd = calendarView === "month" ? endOfWeek(endOfMonth(currentWeek)).toISOString() : weekEnd;
   // const [enrollments, setEnrollments] = useState<Enrollment[]>([]);
   // const [meetings, setMeetings] = useState<Meeting[]>([]);
   // const [students, setStudents] = useState<Profile[]>([]);
@@ -199,8 +214,8 @@ const Schedule = ({
   const query = useQueries({
     queries: [
       {
-        queryKey: ["sessions", weekStart, weekEnd],
-        queryFn: () => getAllSessions(weekStart, weekEnd, "date", true),
+        queryKey: ["sessions", queryStart, queryEnd],
+        queryFn: () => getAllSessions(queryStart, queryEnd, "date", true),
       },
       {
         queryKey: ["students"],
@@ -472,9 +487,7 @@ const Schedule = ({
       // return { prevSessions };
     },
     onSuccess: (newSessions: Session[]) => {
-      queryClient.invalidateQueries({
-        queryKey: ["sessions", weekStart, weekEnd],
-      });
+      queryClient.invalidateQueries({ queryKey: ["sessions"] }); // broad invalidation catches any date range
       toast.success(`${newSessions.length} new sessions added successfully`);
     },
     onError: (error: any, _, context) => {
@@ -502,45 +515,35 @@ const Schedule = ({
     updateWeekMutation.mutate({ enrollments: freshEnrollments });
   };
 
-  // Filter sessions with valid dates for display
-  const getValidSessionsForDay = (day: Date) => {
-    return sessions.filter((session) => {
-      if (!session?.date) return false;
+  // pre-group sessions by day for perf, avoids filtering per cell
+  const sessionsByDay = useMemo(() => {
+    const map = new Map<string, Session[]>();
+    for (const session of sessions) {
+      if (!session?.date) continue;
       try {
-        if (
-          !enrollmentsResult.isLoading &&
-          session.enrollmentId &&
-          !activeEnrollmentIds.has(session.enrollmentId)
-        ) {
-          return false;
-        }
-        return (
-          format(
-            toZonedTime(parseISO(session.date), "America/New_York"),
-            "yyyy-MM-dd",
-          ) === format(day, "yyyy-MM-dd")
-        );
-      } catch (error) {
-        console.error("Error filtering session:", error);
-        return false;
-      }
-    });
-  };
+        if (!enrollmentsResult.isLoading && session.enrollmentId && !activeEnrollmentIds.has(session.enrollmentId)) continue;
+        const dayKey = format(toZonedTime(parseISO(session.date), "America/New_York"), "yyyy-MM-dd");
+        if (!map.has(dayKey)) map.set(dayKey, []);
+        map.get(dayKey)!.push(session);
+      } catch {}
+    }
+    return map;
+  }, [sessions, enrollmentsResult.isLoading, activeEnrollmentIds]);
+
+  const getValidSessionsForDay = (day: Date) => sessionsByDay.get(format(day, "yyyy-MM-dd")) || [];
 
   const removeSessionMutation = useMutation({
     mutationFn: (sessionId: string) => removeSession(sessionId),
     onMutate: async (sessionId: string) => {
-      await queryClient.cancelQueries({
-        queryKey: ["sessions", weekStart, weekEnd],
-      });
+      await queryClient.cancelQueries({ queryKey: ["sessions"] });
       const prevSessions = queryClient.getQueryData<Session[]>([
         "sessions",
-        weekStart,
-        weekEnd,
+        queryStart,
+        queryEnd,
       ]);
 
       queryClient.setQueryData(
-        ["sessions", weekStart, weekEnd],
+        ["sessions", queryStart, queryEnd],
         (sessions: Session[] | undefined) =>
           sessions
             ? sessions.filter((session) => session.id !== sessionId)
@@ -556,7 +559,7 @@ const Schedule = ({
     onError: (error: any, sessionId, context) => {
       if (context) {
         queryClient.setQueryData(
-          ["sessions", weekStart, weekEnd],
+          ["sessions", queryStart, queryEnd],
           context.prevSessions,
         );
       }
@@ -564,9 +567,7 @@ const Schedule = ({
       toast.error("Failed to remove session");
     },
     onSettled: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["sessions", weekStart, weekEnd],
-      });
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
     },
   });
 
@@ -579,7 +580,7 @@ const Schedule = ({
       await updateSession(updatedSession);
       toast.success("Session updated successfully");
       setIsModalOpen(false);
-      fetchSessions(weekStart, weekEnd);
+      fetchSessions(queryStart, queryEnd);
     } catch (error) {
       console.error("Failed to update session:", error);
       toast.error("Failed to update session");
@@ -639,378 +640,465 @@ const Schedule = ({
     end: endOfWeek(currentWeek),
   });
 
-  const goToPreviousWeek = () =>
-    setCurrentWeek((prevWeek) => subWeeks(prevWeek, 1));
-  const goToNextWeek = () =>
-    setCurrentWeek((prevWeek) => addWeeks(prevWeek, 1));
-
-  const getEnrollmentProgress = () => {
-    const totalStudents = students.length;
-    const studentsThisWeek = new Set(
-      sessions.map((session) => session?.student?.id),
-    ).size;
-    return { totalStudents, studentsThisWeek };
+  // nav for all three views
+  const goToPrevious = () => {
+    if (calendarView === "day") setSelectedDay((d) => subDays(d, 1));
+    else if (calendarView === "week") setCurrentWeek((w) => subWeeks(w, 1));
+    else setCurrentWeek((w) => subMonths(w, 1));
+  };
+  const goToNext = () => {
+    if (calendarView === "day") setSelectedDay((d) => addDays(d, 1));
+    else if (calendarView === "week") setCurrentWeek((w) => addWeeks(w, 1));
+    else setCurrentWeek((w) => addMonths(w, 1));
+  };
+  const goToToday = () => {
+    const today = new Date();
+    setCurrentWeek(today);
+    setSelectedDay(today);
   };
 
-  // calc total and unique sessions for the week
-  const getSessionStatistics = () => {
-    const totalSessions = sessions.length;
-    const tutorsInvolved = new Set(
-      sessions.map((session) => session?.tutor?.id),
-    ).size;
-    return { totalSessions, tutorsInvolved };
+  // hours for the time grid, 7am to 10pm
+  const HOURS = Array.from({ length: 16 }, (_, i) => i + 7);
+
+  // figure out which hour row a session falls into
+  const getSessionHour = (dateStr: string) => {
+    const d = toZonedTime(parseISO(dateStr), "America/New_York");
+    return d.getHours();
+  };
+  const getSessionMinutes = (dateStr: string) => {
+    const d = toZonedTime(parseISO(dateStr), "America/New_York");
+    return d.getMinutes();
   };
 
-  const handleGetMissingSEF = async () => {
-    try {
-      await getEnrollmentsWithMissingSEF();
-      toast.success("Printed to console");
-    } catch (error) {
-      console.error(error);
-      toast.error("Please view Dev Console for error");
-    }
+  // month view helpers
+  const monthStart = startOfMonth(currentWeek);
+  const monthEnd = endOfMonth(currentWeek);
+  const monthCalendarStart = startOfWeek(monthStart);
+  const monthCalendarEnd = endOfWeek(monthEnd);
+  const monthDays = eachDayOfInterval({ start: monthCalendarStart, end: monthCalendarEnd });
+
+  // memoized stats so we don't recompute every render
+  const sessionStats = useMemo(() => ({
+    totalSessions: sessions.length,
+    tutorsInvolved: new Set(sessions.map((s) => s?.tutor?.id)).size,
+    studentsThisWeek: new Set(sessions.map((s) => s?.student?.id)).size,
+    totalStudents: students.length,
+  }), [sessions, students]);
+
+  // session card used in all views
+  const SessionCard = ({ session }: { session: Session }) => (
+    <div
+      onClick={() => {
+        setSelectedSession(session);
+        setIsModalOpen(true);
+      }}
+      className={cn(
+        "rounded-md px-2 py-1 text-xs cursor-pointer border-l-2 truncate hover:shadow-md transition-shadow",
+        session.status === "Complete"
+          ? "bg-green-50 border-l-green-500 text-green-900"
+          : session.status === "Cancelled"
+            ? "bg-red-50 border-l-red-500 text-red-900"
+            : "bg-blue-50 border-l-blue-500 text-blue-900"
+      )}
+    >
+      <p className="font-medium truncate">
+        {session.tutor?.firstName} {session.tutor?.lastName}
+      </p>
+      <p className="truncate text-[11px] opacity-80">
+        {session.student?.firstName} {session.student?.lastName}
+      </p>
+      <p className="text-[10px] opacity-60">
+        {getSessionTimespan(session.date, session.duration)}
+      </p>
+    </div>
+  );
+
+  // header text for current view
+  const getHeaderText = () => {
+    if (calendarView === "day") return format(selectedDay, "EEEE, MMMM d, yyyy");
+    if (calendarView === "month") return format(currentWeek, "MMMM yyyy");
+    return `${format(weekDays[0], "MMM d")} - ${format(weekDays[6], "MMM d, yyyy")}`;
   };
 
   return (
     <>
       <Toaster />
-      <div className="p-8 bg-gray-100 min-h-screen">
-        <h1 className="text-3xl font-bold mb-6 text-left text-gray-800">
-          Schedule
-        </h1>
+      <div className="p-6 bg-gray-50 min-h-screen">
+        {/* top bar */}
+        <div className="bg-white rounded-xl shadow-sm p-4 mb-4">
+          <div className="flex items-center justify-between flex-wrap gap-3">
+            {/* left side: nav */}
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" onClick={goToToday}>
+                Today
+              </Button>
+              <Button variant="ghost" size="icon" onClick={goToPrevious}>
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <Button variant="ghost" size="icon" onClick={goToNext}>
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+              <h2 className="text-lg font-semibold text-gray-800 ml-2">
+                {getHeaderText()}
+              </h2>
+            </div>
 
-        <div className="bg-white rounded-lg shadow-sm p-6 mb-6">
-          <div className="flex justify-between items-center mb-6">
-            <Button
-              variant="outline"
-              onClick={goToPreviousWeek}
-              className="flex items-center"
-            >
-              <ChevronLeft className="w-5 h-5 mr-2" /> Previous Week
-            </Button>
-            <h2 className="text-xl font-semibold text-gray-700">
-              {format(weekDays[0], "MMMM d, yyyy")} -{" "}
-              {format(weekDays[6], "MMMM d, yyyy")}
-            </h2>
-            <Button
-              variant="outline"
-              onClick={goToNextWeek}
-              className="flex items-center"
-            >
-              Next Week <ChevronRight className="w-5 h-5 ml-2" />
-            </Button>
+            {/* right side: view toggle and actions */}
+            <div className="flex items-center gap-2">
+              {/* view toggle */}
+              <div className="flex bg-gray-100 rounded-lg p-0.5">
+                {(["day", "week", "month"] as const).map((view) => (
+                  <button
+                    key={view}
+                    onClick={() => setCalendarView(view)}
+                    className={cn(
+                      "px-3 py-1.5 text-sm font-medium rounded-md transition-colors capitalize",
+                      calendarView === view
+                        ? "bg-white shadow-sm text-gray-900"
+                        : "text-gray-500 hover:text-gray-700"
+                    )}
+                  >
+                    {view}
+                  </button>
+                ))}
+              </div>
+
+              <Button
+                onClick={handleUpdateWeek}
+                disabled={isLoading}
+                size="sm"
+                className="bg-connect-me-blue-3 hover:bg-connect-me-blue-4"
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                    Loading
+                  </>
+                ) : (
+                  "Update Week"
+                )}
+              </Button>
+
+              <Dialog>
+                <DialogTrigger asChild>
+                  <Button size="sm" className="bg-connect-me-blue-4 hover:bg-connect-me-blue-5">
+                    Add Session
+                  </Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Add Session</DialogTitle>
+                  </DialogHeader>
+                  <ScrollArea className="pr-4">
+                    <div className="grid gap-4 py-4">
+                      <ProfileSelector
+                        label="Student"
+                        profiles={students}
+                        selectedId={selectedStudentId}
+                        onSelect={(id) => {
+                          setSelectedStudentId(id);
+                          handleInputChange({ target: { name: "student.id", value: id } });
+                        }}
+                        placeholder="Select a student"
+                      />
+                      <ProfileSelector
+                        label="Tutor"
+                        profiles={tutors}
+                        selectedId={selectedTutorId}
+                        onSelect={(id) => {
+                          setSelectedTutorId(id);
+                          handleInputChange({ target: { name: "tutor.id", value: id } });
+                        }}
+                        placeholder="Select a tutor"
+                      />
+                      <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="startDate" className="text-right">Date</Label>
+                        <Input
+                          id="startDate"
+                          name="startDate"
+                          type="datetime-local"
+                          defaultValue={formatDateForInput(newSession.date)}
+                          onBlur={async (e) => {
+                            const scheduledDate = new Date(e.target.value);
+                            const updatedSession: Partial<Session> = {
+                              ...newSession,
+                              date: scheduledDate.toISOString(),
+                            };
+                            await checkMeetingAvailabilites(updatedSession as Session);
+                            setNewSession(updatedSession);
+                          }}
+                          disabled={isCheckingMeetingAvailability}
+                          className="col-span-3"
+                        />
+                      </div>
+                      <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="duration" className="text-right">Duration</Label>
+                        <div className="col-span-3">
+                          <Select
+                            onValueChange={(value) => {
+                              const duration = parseFloat(value);
+                              const updatedSession: Partial<Session> = { ...newSession, duration };
+                              checkMeetingAvailabilites(updatedSession as Session);
+                              setNewSession(updatedSession);
+                            }}
+                          >
+                            <SelectTrigger className="w-full">
+                              <SelectValue placeholder="Select a time duration" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectGroup>
+                                <SelectLabel>Duration</SelectLabel>
+                                {Array.from({ length: 12 }, (_, i) => (i + 1) * 0.25).map((duration) => {
+                                  const minutes = (duration % 1) * 60;
+                                  const hours = Math.floor(duration);
+                                  return (
+                                    <SelectItem key={duration} value={duration.toString()}>
+                                      {hours} {hours > 1 ? "hours" : "hour"} {minutes} minutes
+                                    </SelectItem>
+                                  );
+                                })}
+                              </SelectGroup>
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      </div>
+                      <div className="grid grid-cols-4 items-center gap-4">
+                        <Label className="text-right">Meeting Link</Label>
+                        <div className="col-span-3">
+                          <Select
+                            value={newSession?.meeting?.id || ""}
+                            onValueChange={async (value) => {
+                              setNewSession({ ...newSession, meeting: await getMeeting(value) });
+                            }}
+                          >
+                            <SelectTrigger>
+                              <SelectValue>
+                                {newSession?.meeting?.name || "Select a meeting"}
+                              </SelectValue>
+                            </SelectTrigger>
+                            <SelectContent>
+                              {meetings.map((meeting) => (
+                                <SelectItem key={meeting.id} value={meeting.id} className="flex items-center justify-between">
+                                  <span>{meeting.name}</span>
+                                  <Circle
+                                    className={`w-2 h-2 ml-2 ${
+                                      meetingAvailabilityMap[meeting.id] ? "text-green-500" : "text-red-500"
+                                    } fill-current`}
+                                  />
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      </div>
+                      <Button
+                        onClick={handleAddSession}
+                        disabled={isCheckingMeetingAvailability}
+                        className="bg-connect-me-blue-3"
+                      >
+                        {isCheckingMeetingAvailability ? (
+                          <>
+                            Checking Meeting Availability
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          </>
+                        ) : (
+                          "Add Session"
+                        )}
+                      </Button>
+                    </div>
+                  </ScrollArea>
+                </DialogContent>
+              </Dialog>
+            </div>
           </div>
 
-          <Button
-            onClick={handleUpdateWeek}
-            disabled={isLoading}
-            className="mb-4 bg-connect-me-blue-2"
-          >
-            {isLoading ? (
-              <>
-                Loading Sessions{"  "}
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              </>
-            ) : (
-              "Update Week"
-            )}
-          </Button>
-          <Dialog>
-            <DialogTrigger asChild>
-              <Button className="mx-4 bg-connect-me-blue-3">Add Session</Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Add Session</DialogTitle>
-              </DialogHeader>
-
-              <ScrollArea className="pr-4">
-                {" "}
-                <div className="grid gap-4 py-4">
-                  <ProfileSelector
-                    label="Student"
-                    profiles={students}
-                    selectedId={selectedStudentId}
-                    onSelect={(id) => {
-                      setSelectedStudentId(id);
-                      handleInputChange({
-                        target: { name: "student.id", value: id },
-                      });
-                    }}
-                    placeholder="Select a student"
-                  />
-
-                  <ProfileSelector
-                    label="Tutor"
-                    profiles={tutors}
-                    selectedId={selectedTutorId}
-                    onSelect={(id) => {
-                      setSelectedTutorId(id);
-                      handleInputChange({
-                        target: { name: "tutor.id", value: id },
-                      });
-                    }}
-                    placeholder="Select a tutor"
-                  />
-                  <div className="grid grid-cols-4 items-center gap-4">
-                    <Label htmlFor="startDate" className="text-right">
-                      Date
-                    </Label>
-                    <Input
-                      id="startDate"
-                      name="startDate"
-                      type="datetime-local"
-                      defaultValue={formatDateForInput(newSession.date)}
-                      onBlur={async (e) => {
-                        const scheduledDate = new Date(e.target.value);
-                        const updatedSession: Partial<Session> = {
-                          ...newSession,
-                          date: scheduledDate.toISOString(),
-                        };
-                        await checkMeetingAvailabilites(
-                          updatedSession as Session,
-                        );
-                        setNewSession(updatedSession);
-                      }}
-                      disabled={isCheckingMeetingAvailability}
-                      className="col-span-3"
-                    />
-                  </div>
-                  <div className="grid grid-cols-4 items-center gap-4">
-                    <Label htmlFor="duration" className="text-right">
-                      Duration
-                    </Label>{" "}
-                    <div className="col-span-3">
-                      {" "}
-                      <Select
-                        onValueChange={(value) => {
-                          const duration = parseFloat(value);
-                          const updatedSession: Partial<Session> = {
-                            ...newSession,
-                            duration: duration,
-                          };
-                          checkMeetingAvailabilites(updatedSession as Session);
-                          setNewSession(updatedSession);
-                        }}
-                      >
-                        <SelectTrigger className="w-full">
-                          <SelectValue placeholder="Select a time duration" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectGroup>
-                            <SelectLabel>Duration</SelectLabel>
-                            {Array.from(
-                              { length: 12 },
-                              (_, i) => (i + 1) * 0.25,
-                            ).map((duration) => {
-                              const minutes = (duration % 1) * 60;
-                              const hours = Math.floor(duration);
-
-                              return (
-                                <SelectItem
-                                  key={duration}
-                                  value={duration.toString()}
-                                >
-                                  {hours} {hours > 1 ? "hours" : "hour"}{" "}
-                                  {minutes} minutes
-                                </SelectItem>
-                              );
-                            })}
-                          </SelectGroup>
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  </div>
-                  <div className="grid grid-cols-4 items-center gap-4">
-                    <Label htmlFor="" className="text-right">
-                      Meeting Link
-                    </Label>
-                    <div className="col-span-3">
-                      {" "}
-                      <Select
-                        value={newSession?.meeting?.id || ""}
-                        onOpenChange={(open) => {
-                          if (open && newSession) {
-                          }
-                        }}
-                        onValueChange={async (value) => {
-                          setNewSession({
-                            ...newSession,
-                            meeting: await getMeeting(value),
-                          });
-                        }}
-                      >
-                        <SelectTrigger>
-                          <SelectValue>
-                            {newSession?.meeting?.name || "Select a meeting"}
-                          </SelectValue>
-                        </SelectTrigger>
-                        <SelectContent>
-                          {meetings.map((meeting) => (
-                            <SelectItem
-                              key={meeting.id}
-                              value={meeting.id}
-                              className="flex items-center justify-between"
-                            >
-                              <span>{meeting.name}</span>
-                              <Circle
-                                className={`w-2 h-2 ml-2 ${
-                                  meetingAvailabilityMap[meeting.id]
-                                    ? "text-green-500"
-                                    : "text-red-500"
-                                } fill-current`}
-                              />
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  </div>
-
-                  {/* Other form fields */}
-                  <Button
-                    onClick={handleAddSession}
-                    disabled={isCheckingMeetingAvailability}
-                    className="bg-connect-me-blue-3"
-                  >
-                    {isCheckingMeetingAvailability ? (
-                      <>
-                        Checking Meeting Availability
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      </>
-                    ) : (
-                      "Add Session"
-                    )}
-                  </Button>
-                </div>
-              </ScrollArea>
-            </DialogContent>
-          </Dialog>
-          <Button
-            className="bg-connect-me-blue-4"
-            onClick={() => handleGetMissingSEF()}
-          >
-            Function Tester
-          </Button>
-
-          {isLoading ? (
-            <div className="text-center py-10">
-              <Calendar className="w-10 h-10 animate-spin mx-auto text-blue-500" />
-              <p className="mt-4 text-gray-600">Loading sessions...</p>
-            </div>
-          ) : (
-            <div className="grid grid-cols-7 gap-2">
-              {weekDays.map((day) => (
-                <div
-                  key={day.toISOString()}
-                  className="border rounded-lg px-2 py-3 bg-gray-50"
-                >
-                  <h3 className="font-semibold mb-2 text-gray-700">
-                    {format(day, "EEEE")}
-                  </h3>
-                  <p className="text-sm mb-4 text-gray-500">
-                    {format(day, "MMM d")}
-                  </p>
-                  {getValidSessionsForDay(day).map((session) => (
-                    <Card
-                      onClick={() => {
-                        setSelectedSession(session);
-                        setIsModalOpen(true);
-                      }}
-                      key={session.id}
-                      className={`hover:cursor-pointer hover:shadow-md mb-2 ${
-                        session.status === "Complete"
-                          ? "bg-green-500/10 border-2"
-                          : session.status === "Cancelled"
-                            ? "bg-red-500/10 border-2"
-                            : "bg-white"
-                      }`}
-                    >
-                      <CardContent className="p-3">
-                        <p className="text-xs font-semibold">
-                          {session.tutor?.firstName} {session.tutor?.lastName}
-                        </p>
-                        <p className="text-xs font-normal">
-                          {session?.student?.firstName}{" "}
-                          {session?.student?.lastName}
-                        </p>
-                        <p className="text-xs text-gray-500">
-                          {session.summary}
-                        </p>
-                        <p className="text-xs text-gray-500">
-                          {getSessionTimespan(session.date, session.duration)}{" "}
-                          EDT
-                        </p>
-                        <div
-                          className={`text-xs font-medium px-2 py-1 rounded-lg mt-1 border ${
-                            session.meeting != null
-                              ? "border-green-300 text-green-700"
-                              : "bg-red-100 text-red-700"
-                          }`}
-                        >
-                          {session?.meeting != null &&
-                          session?.meeting.name != null
-                            ? session?.meeting.name
-                            : "No Meeting Link"}
-                        </div>
-
-                        <Button
-                          className="hidden mt-2 w-full text-xs h-6"
-                          onClick={() => {
-                            setSelectedSession(session);
-                            setIsModalOpen(true);
-                          }}
-                          variant="outline"
-                        >
-                          View Details
-                        </Button>
-                      </CardContent>
-                    </Card>
-                  ))}
-                  {sessions.filter(
-                    (session) =>
-                      session?.date &&
-                      format(parseISO(session.date), "yyyy-MM-dd") ===
-                        format(day, "yyyy-MM-dd"),
-                  ).length === 0 && (
-                    <p className="text-sm text-gray-400 text-center">
-                      No sessions
-                    </p>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
+          {/* stats bar */}
+          <div className="flex items-center gap-6 mt-3 pt-3 border-t text-sm text-gray-500">
+            <span>
+              <span className="font-medium text-gray-700">{sessionStats.totalSessions}</span> sessions
+            </span>
+            <span>
+              <span className="font-medium text-gray-700">{sessionStats.tutorsInvolved}</span> tutors
+            </span>
+            <span>
+              <span className="font-medium text-gray-700">{sessionStats.studentsThisWeek}</span> / {sessionStats.totalStudents} students
+            </span>
+          </div>
         </div>
 
-        <div>
-          <h3 className="text-3xl font-bold mb-6 text-left text-gray-800">
-            Enrollment Progress
-          </h3>
-          <Card className="mb-6">
-            <CardContent className="p-6">
-              <div className="grid grid-cols-4 gap-4">
-                <div>
-                  <p className="font-medium">Total Students:</p>
-                  <p>{getEnrollmentProgress().totalStudents}</p>
+        {/* loading state */}
+        {isLoading ? (
+          <div className="bg-white rounded-xl shadow-sm p-10">
+            <div className="text-center">
+              <Calendar className="w-8 h-8 animate-spin mx-auto text-blue-500" />
+              <p className="mt-3 text-gray-500 text-sm">Loading sessions...</p>
+            </div>
+          </div>
+        ) : (
+          <>
+            {/* week view, the main google calendar style grid */}
+            {calendarView === "week" && (
+              <div className="bg-white rounded-xl shadow-sm overflow-hidden">
+                {/* day headers */}
+                <div className="grid grid-cols-[60px_repeat(7,1fr)] border-b">
+                  <div className="border-r" /> {/* spacer for time col */}
+                  {weekDays.map((day) => (
+                    <div
+                      key={day.toISOString()}
+                      className={cn(
+                        "text-center py-3 border-r last:border-r-0",
+                        isToday(day) && "bg-blue-50"
+                      )}
+                    >
+                      <p className="text-xs text-gray-500 uppercase">{format(day, "EEE")}</p>
+                      <p className={cn(
+                        "text-lg font-semibold",
+                        isToday(day)
+                          ? "bg-blue-600 text-white rounded-full w-8 h-8 flex items-center justify-center mx-auto"
+                          : "text-gray-800"
+                      )}>
+                        {format(day, "d")}
+                      </p>
+                    </div>
+                  ))}
                 </div>
-                <div>
-                  <p className="font-medium"># Of Unique Students This Week:</p>
-                  <p>{getEnrollmentProgress().studentsThisWeek}</p>
-                </div>
-                <div>
-                  <p className="font-medium">Total Sessions This Week:</p>
-                  <p>{getSessionStatistics().totalSessions}</p>
-                </div>
-                <div>
-                  <p className="font-medium">Tutors Involved This Week:</p>
-                  <p>{getSessionStatistics().tutorsInvolved}</p>
+
+                {/* time grid - no scroll, all sessions visible */}
+                <div className="grid grid-cols-[60px_repeat(7,1fr)]">
+                  {HOURS.map((hour) => (
+                    <React.Fragment key={hour}>
+                      <div className="border-r border-b min-h-[36px] flex items-start justify-end pr-2 pt-1">
+                        <span className="text-[11px] text-gray-400">
+                          {hour === 0 ? "12:00 AM" : hour < 12 ? `${hour}:00 AM` : hour === 12 ? "12:00 PM" : `${hour - 12}:00 PM`}
+                        </span>
+                      </div>
+                      {weekDays.map((day) => {
+                        const daySessions = getValidSessionsForDay(day).filter(
+                          (s) => getSessionHour(s.date) === hour
+                        );
+                        return (
+                          <div
+                            key={`${day.toISOString()}-${hour}`}
+                            className={cn(
+                              "border-r border-b last:border-r-0 min-h-[36px] p-[2px] space-y-0.5",
+                              isToday(day) && "bg-blue-50/30"
+                            )}
+                          >
+                            {daySessions.map((session) => (
+                              <SessionCard key={session.id} session={session} />
+                            ))}
+                          </div>
+                        );
+                      })}
+                    </React.Fragment>
+                  ))}
                 </div>
               </div>
-            </CardContent>
-          </Card>
-        </div>
+            )}
 
+            {/* day view */}
+            {calendarView === "day" && (
+              <div className="bg-white rounded-xl shadow-sm overflow-hidden">
+                <div className="grid grid-cols-[60px_1fr]">
+                  {/* header */}
+                  <div className="border-r border-b" />
+                  <div className={cn("py-3 px-4 border-b", isToday(selectedDay) && "bg-blue-50")}>
+                    <p className="text-xs text-gray-500 uppercase">{format(selectedDay, "EEEE")}</p>
+                    <p className={cn(
+                      "text-2xl font-semibold",
+                      isToday(selectedDay) ? "text-blue-600" : "text-gray-800"
+                    )}>
+                      {format(selectedDay, "d")}
+                    </p>
+                  </div>
+                </div>
+                <div className="grid grid-cols-[60px_1fr]">
+                  {HOURS.map((hour) => {
+                    const daySessions = getValidSessionsForDay(selectedDay).filter(
+                      (s) => getSessionHour(s.date) === hour
+                    );
+                    return (
+                      <React.Fragment key={hour}>
+                        <div className="border-r border-b min-h-[36px] flex items-start justify-end pr-2 pt-1">
+                          <span className="text-[11px] text-gray-400">
+                            {hour === 0 ? "12:00 AM" : hour < 12 ? `${hour}:00 AM` : hour === 12 ? "12:00 PM" : `${hour - 12}:00 PM`}
+                          </span>
+                        </div>
+                        <div className={cn("border-b min-h-[36px] p-[2px] space-y-0.5", isToday(selectedDay) && "bg-blue-50/30")}>
+                          {daySessions.map((session) => (
+                            <SessionCard key={session.id} session={session} />
+                          ))}
+                        </div>
+                      </React.Fragment>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* month view */}
+            {calendarView === "month" && (
+              <div className="bg-white rounded-xl shadow-sm overflow-hidden">
+                {/* day of week headers */}
+                <div className="grid grid-cols-7 border-b">
+                  {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((d) => (
+                    <div key={d} className="text-center py-2 text-xs font-medium text-gray-500 uppercase border-r last:border-r-0">
+                      {d}
+                    </div>
+                  ))}
+                </div>
+                {/* calendar grid */}
+                <div className="grid grid-cols-7">
+                  {monthDays.map((day) => {
+                    const daySessions = getValidSessionsForDay(day);
+                    return (
+                      <div
+                        key={day.toISOString()}
+                        className={cn(
+                          "border-r border-b last:border-r-0 min-h-[100px] p-1",
+                          !isSameMonth(day, currentWeek) && "bg-gray-50 opacity-50",
+                          isToday(day) && "bg-blue-50"
+                        )}
+                      >
+                        <p className={cn(
+                          "text-xs font-medium mb-1",
+                          isToday(day)
+                            ? "bg-blue-600 text-white rounded-full w-5 h-5 flex items-center justify-center"
+                            : "text-gray-600"
+                        )}>
+                          {format(day, "d")}
+                        </p>
+                        <div className="space-y-0.5">
+                          {daySessions.map((session) => (
+                            <div
+                              key={session.id}
+                              onClick={() => {
+                                setSelectedSession(session);
+                                setIsModalOpen(true);
+                              }}
+                              className={cn(
+                                "text-[10px] px-1 py-0.5 rounded truncate cursor-pointer",
+                                session.status === "Complete"
+                                  ? "bg-green-100 text-green-800"
+                                  : session.status === "Cancelled"
+                                    ? "bg-red-100 text-red-800"
+                                    : "bg-blue-100 text-blue-800"
+                              )}
+                            >
+                              {session.tutor?.firstName} / {session.student?.firstName}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* session details modal, keeping all existing fields */}
         <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
           <DialogContent>
             <DialogHeader>
@@ -1022,24 +1110,14 @@ const Schedule = ({
                   <Label>Status</Label>
                   <Select
                     value={selectedSession?.status}
-                    onValueChange={(
-                      value: "Active" | "Complete" | "Cancelled",
-                    ) => {
+                    onValueChange={(value: "Active" | "Complete" | "Cancelled") => {
                       if (value && selectedSession) {
-                        const updatedSession = {
-                          ...selectedSession,
-                          status: value,
-                        };
-                        setSelectedSession(updatedSession);
+                        setSelectedSession({ ...selectedSession, status: value });
                       }
                     }}
                   >
                     <SelectTrigger>
-                      <SelectValue>
-                        {selectedSession?.status
-                          ? selectedSession.status
-                          : "Select status"}
-                      </SelectValue>
+                      <SelectValue>{selectedSession?.status || "Select status"}</SelectValue>
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="Active">Active</SelectItem>
@@ -1053,14 +1131,8 @@ const Schedule = ({
                   <Select
                     value={selectedSession.tutor?.id}
                     onValueChange={async (value) => {
-                      const selectedTutor =
-                        await getProfileWithProfileId(value);
-                      if (selectedTutor) {
-                        setSelectedSession({
-                          ...selectedSession,
-                          tutor: selectedTutor,
-                        });
-                      }
+                      const selectedTutor = await getProfileWithProfileId(value);
+                      if (selectedTutor) setSelectedSession({ ...selectedSession, tutor: selectedTutor });
                     }}
                   >
                     <SelectTrigger>
@@ -1071,13 +1143,12 @@ const Schedule = ({
                       </SelectValue>
                     </SelectTrigger>
                     <SelectContent>
-                      {tutors.map(
-                        (tutor) =>
-                          tutor.status !== "Inactive" && (
-                            <SelectItem key={tutor.id} value={tutor.id}>
-                              {tutor.firstName} {tutor.lastName}
-                            </SelectItem>
-                          ),
+                      {tutors.map((tutor) =>
+                        tutor.status !== "Inactive" && (
+                          <SelectItem key={tutor.id} value={tutor.id}>
+                            {tutor.firstName} {tutor.lastName}
+                          </SelectItem>
+                        )
                       )}
                     </SelectContent>
                   </Select>
@@ -1087,14 +1158,8 @@ const Schedule = ({
                   <Select
                     value={selectedSession.student?.id}
                     onValueChange={async (value) => {
-                      const selectedStudent =
-                        await getProfileWithProfileId(value);
-                      if (selectedStudent) {
-                        setSelectedSession({
-                          ...selectedSession,
-                          student: selectedStudent,
-                        });
-                      }
+                      const selectedStudent = await getProfileWithProfileId(value);
+                      if (selectedStudent) setSelectedSession({ ...selectedSession, student: selectedStudent });
                     }}
                   >
                     <SelectTrigger>
@@ -1105,13 +1170,12 @@ const Schedule = ({
                       </SelectValue>
                     </SelectTrigger>
                     <SelectContent>
-                      {students.map(
-                        (student) =>
-                          student.status !== "Inactive" && (
-                            <SelectItem key={student.id} value={student.id}>
-                              {student.firstName} {student.lastName}
-                            </SelectItem>
-                          ),
+                      {students.map((student) =>
+                        student.status !== "Inactive" && (
+                          <SelectItem key={student.id} value={student.id}>
+                            {student.firstName} {student.lastName}
+                          </SelectItem>
+                        )
                       )}
                     </SelectContent>
                   </Select>
@@ -1120,20 +1184,11 @@ const Schedule = ({
                   <Label>Date</Label>
                   <Input
                     type="datetime-local"
-                    defaultValue={format(
-                      parseISO(selectedSession.date),
-                      "yyyy-MM-dd'T'HH:mm",
-                    )}
+                    defaultValue={format(parseISO(selectedSession.date), "yyyy-MM-dd'T'HH:mm")}
                     onBlur={(e) => {
                       const scheduledDate = new Date(e.target.value);
-                      setSelectedSession({
-                        ...selectedSession,
-                        date: scheduledDate.toISOString(),
-                      });
-                      checkMeetingAvailabilites(
-                        selectedSession as Session,
-                        // scheduledDate
-                      );
+                      setSelectedSession({ ...selectedSession, date: scheduledDate.toISOString() });
+                      checkMeetingAvailabilites(selectedSession as Session);
                     }}
                   />
                 </div>
@@ -1141,35 +1196,20 @@ const Schedule = ({
                   <Label>Meeting</Label>
                   <Select
                     value={selectedSession?.meeting?.id || ""}
-                    onOpenChange={(open) => {}}
                     onValueChange={async (value) =>
-                      setSelectedSession({
-                        ...selectedSession,
-                        meeting: await getMeeting(value),
-                      })
+                      setSelectedSession({ ...selectedSession, meeting: await getMeeting(value) })
                     }
                   >
                     <SelectTrigger>
-                      <SelectValue>
-                        {selectedSession?.meeting?.name || "Select a meeting"}
-                      </SelectValue>
+                      <SelectValue>{selectedSession?.meeting?.name || "Select a meeting"}</SelectValue>
                     </SelectTrigger>
                     <SelectContent>
                       {meetings.map((meeting) => (
-                        <SelectItem
-                          key={meeting.id}
-                          value={meeting.id}
-                          className="flex items-center justify-between"
-                        >
-                          {/* <span>
-                          {meeting.name} - {meeting.id}
-                        </span> */}
+                        <SelectItem key={meeting.id} value={meeting.id} className="flex items-center justify-between">
                           <span>{meeting.name}</span>
                           <Circle
                             className={`w-2 h-2 ml-2 ${
-                              meetingAvailabilityMap[meeting.id]
-                                ? "text-green-500"
-                                : "text-red-500"
+                              meetingAvailabilityMap[meeting.id] ? "text-green-500" : "text-red-500"
                             } fill-current`}
                           />
                         </SelectItem>
@@ -1177,63 +1217,36 @@ const Schedule = ({
                     </SelectContent>
                   </Select>
                 </div>
-
                 <div>
-                  <Label className="text-right">Notes (Only viewable Admin Side)</Label> {/* admin only notes label */}
+                  <Label className="text-right">Notes (Only viewable Admin Side)</Label>
                   <Textarea
                     value={selectedSession?.summary}
-                    onChange={(e) =>
-                      setSelectedSession({
-                        ...selectedSession,
-                        summary: e.target.value,
-                      })
-                    }
-                  ></Textarea>
+                    onChange={(e) => setSelectedSession({ ...selectedSession, summary: e.target.value })}
+                  />
                 </div>
-
                 {(() => {
-                  const rawSef = (selectedSession as any)?.session_exit_form as
-                    | string
-                    | null
-                    | undefined; // pull sef string w null safe
-
-                  const sefFlags: string[] = []; // keep sef boxes tiny
-                  if ((selectedSession as any)?.isQuestionOrConcern)
-                    sefFlags.push("question/concern"); // show tutor box
-                  if ((selectedSession as any)?.isFirstSession)
-                    sefFlags.push("first session"); // show tutor box
-                  if (selectedSession.status === "Cancelled")
-                    sefFlags.push("cancelled"); // quick context
-
-                  let sefReasonText = rawSef ?? ""; // default to raw text
+                  const rawSef = (selectedSession as any)?.session_exit_form as string | null | undefined;
+                  const sefFlags: string[] = [];
+                  if ((selectedSession as any)?.isQuestionOrConcern) sefFlags.push("question/concern");
+                  if ((selectedSession as any)?.isFirstSession) sefFlags.push("first session");
+                  if (selectedSession.status === "Cancelled") sefFlags.push("cancelled");
+                  let sefReasonText = rawSef ?? "";
                   if (rawSef && rawSef.trim().startsWith("{")) {
                     try {
-                      const parsed = JSON.parse(rawSef) as any; // handle future sef json
-                      sefReasonText =
-                        parsed?.reason ??
-                        parsed?.notes ??
-                        parsed?.exitReason ??
-                        rawSef; // prefer explicit reason field
-                      const extraFlags =
-                        parsed?.boxes ?? parsed?.flags ?? parsed?.options; // try grab checkbox list
+                      const parsed = JSON.parse(rawSef) as any;
+                      sefReasonText = parsed?.reason ?? parsed?.notes ?? parsed?.exitReason ?? rawSef;
+                      const extraFlags = parsed?.boxes ?? parsed?.flags ?? parsed?.options;
                       if (Array.isArray(extraFlags)) {
-                        extraFlags
-                          .filter((x) => typeof x === "string")
-                          .forEach((x) => sefFlags.push(x)); // merge extra boxes
+                        extraFlags.filter((x) => typeof x === "string").forEach((x) => sefFlags.push(x));
                       }
                     } catch {
-                      // ignore parse fail, raw text fine
+                      // raw text fine
                     }
                   }
-
                   return (
                     <div>
-                      <Label>SEF Exit Reason</Label> {/* show sef reason */}
-                      <Textarea
-                        readOnly
-                        value={sefReasonText || ""}
-                        placeholder="no session exit form yet"
-                      />
+                      <Label>SEF Exit Reason</Label>
+                      <Textarea readOnly value={sefReasonText || ""} placeholder="no session exit form yet" />
                       <p className="text-xs text-gray-500 mt-1">
                         SEF boxes: {sefFlags.length ? sefFlags.join(", ") : "none"}
                       </p>
@@ -1241,10 +1254,7 @@ const Schedule = ({
                   );
                 })()}
                 <div className="flex flex-col gap-3">
-                  <Link
-                    href={`/dashboard/session/${selectedSession.id}/participation`}
-                    className="w-full"
-                  >
+                  <Link href={`/dashboard/session/${selectedSession.id}/participation`} className="w-full">
                     <Button variant="outline" className="w-full">
                       <Users className="mr-2 h-4 w-4" />
                       View Session Participation
@@ -1264,10 +1274,7 @@ const Schedule = ({
                         "Update Session"
                       )}
                     </Button>
-                    <Button
-                      variant="destructive"
-                      onClick={() => handleRemoveSession(selectedSession.id)}
-                    >
+                    <Button variant="destructive" onClick={() => handleRemoveSession(selectedSession.id)}>
                       Delete Session
                     </Button>
                   </div>


### PR DESCRIPTION
Adds a search bar to the schedule page that lets you look up sessions by tutor name, student name, or email. typing into it filters down the calendar in real time across all views (day, week, month). the session counts and stats update to reflect the filtered results too. theres an x button to clear the search.

also merges in the googleCalAdmin branch so this pr includes the calendar view improvements (day/week/month toggle, session grouping, date picker, etc.) that were on gca but not yet on dev.
closes #499 