### PR TITLE
Enrollment history

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -88,18 +88,3 @@
     @apply bg-background text-foreground;
   }
 }
-
-@media (min-width: 1280px) {
-  .app-scale-shell {
-    zoom: var(--app-scale-factor);
-  }
-
-  @supports not (zoom: 1) {
-    .app-scale-shell {
-      min-height: calc(100vh / var(--app-scale-factor));
-      transform: scale(var(--app-scale-factor));
-      transform-origin: top left;
-      width: calc(100% / var(--app-scale-factor));
-    }
-  }
-}

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,6 +7,7 @@
     --clr-gray-light: rgb(249, 248, 248);
     --clr-gray-base: rgb(218, 218, 218);
     --clr-gray-dark: rgb(114, 110, 110);
+    --app-scale-factor: 0.9;
 
     --background: 0 0% 100%;
     --foreground: 0 0% 3.9%;
@@ -85,5 +86,20 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@media (min-width: 1280px) {
+  .app-scale-shell {
+    zoom: var(--app-scale-factor);
+  }
+
+  @supports not (zoom: 1) {
+    .app-scale-shell {
+      min-height: calc(100vh / var(--app-scale-factor));
+      transform: scale(var(--app-scale-factor));
+      transform-origin: top left;
+      width: calc(100% / var(--app-scale-factor));
+    }
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,9 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <PostHogProvider>
-          {children}
+          <div className="app-scale-shell">
+            {children}
+          </div>
           {/* <SpeedInsights /> */}
         </PostHogProvider>
       </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,9 +22,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <PostHogProvider>
-          <div className="app-scale-shell">
-            {children}
-          </div>
+          {children}
           {/* <SpeedInsights /> */}
         </PostHogProvider>
       </body>

--- a/components/admin/EnrollmentsManagement.tsx
+++ b/components/admin/EnrollmentsManagement.tsx
@@ -81,7 +81,7 @@ import {
   updateEnrollment,
 } from "@/lib/actions/enrollment.server.actions";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import { Enrollment, Profile, Event, Meeting, Availability } from "@/types";
+import { Enrollment, Profile, Event, Meeting, Availability, Session } from "@/types";
 import toast from "react-hot-toast";
 import AvailabilityFormat from "@/components/student/AvailabilityFormat";
 import AvailabilityForm from "@/components/ui/availability-form";
@@ -94,6 +94,10 @@ import { useRouter } from "next/navigation";
 import { checkAvailableMeetingForEnrollments } from "@/lib/actions/meeting.actions";
 import { formatDateServer } from "@/lib/actions/utils.server.actions";
 import { QueryClient } from "@tanstack/react-query";
+import { getSessionsByEnrollmentId } from "@/lib/actions/session.actions";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet";
+import SessionHistoryPanel from "@/components/admin/SessionHistoryPanel";
+import { History } from "lucide-react";
 // import Availability from "@/components/student/AvailabilityFormat";
 
 const durationSchema = z.object({
@@ -168,6 +172,28 @@ const EnrollmentList = ({
   const [editHoursError, setEditHoursError] = useState<string | null>(null);
   const [minutesError, setMinutesError] = useState<string | null>(null);
   const [editMinutesError, setEditMinutesError] = useState<string | null>();
+
+  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+  const [historyEnrollment, setHistoryEnrollment] = useState<Enrollment | null>(null);
+  const [historySessions, setHistorySessions] = useState<Session[] | null>(null);
+  const [historyLoading, setHistoryLoading] = useState(false);
+
+  const handleViewHistory = async (enrollment: Enrollment) => {
+    setHistoryEnrollment(enrollment);
+    setIsHistoryOpen(true);
+    setHistoryLoading(true);
+    setHistorySessions(null);
+
+    try {
+      const sessions = await getSessionsByEnrollmentId(enrollment.id);
+      setHistorySessions(sessions);
+    } catch (err) {
+      console.error("Failed to fetch enrollment history", err);
+      toast.error("Failed to load session history");
+    } finally {
+      setHistoryLoading(false);
+    }
+  };
 
   const [hours, setHours] = useState(1);
   const [minutes, setMinutes] = useState(0);
@@ -971,6 +997,7 @@ const EnrollmentList = ({
                   "Actions",
                   "Status",
                   "Chat",
+                  "History",
                 ].map((header) => (
                   <TableHead key={header}>{header}</TableHead>
                 ))}
@@ -1102,6 +1129,16 @@ const EnrollmentList = ({
                     >
                       View Chat
                       <MessageCircleIcon />
+                    </Button>
+                  </TableCell>
+
+                  <TableCell>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleViewHistory(enrollment)}
+                    >
+                      <History className="h-4 w-4" />
                     </Button>
                   </TableCell>
                 </TableRow>
@@ -1515,6 +1552,25 @@ const EnrollmentList = ({
           </div>
         </DialogContent>
       </Dialog>
+      <Sheet open={isHistoryOpen} onOpenChange={setIsHistoryOpen}>
+        <SheetContent side="right" className="w-[420px] sm:max-w-[420px]">
+          <SheetHeader className="sr-only">
+            <SheetTitle>Enrollment Session History</SheetTitle>
+            <SheetDescription>Session history for this enrollment</SheetDescription>
+          </SheetHeader>
+          <SessionHistoryPanel
+            sessions={historySessions}
+            loading={historyLoading}
+            title="Enrollment History"
+            subtitle={
+              historyEnrollment
+                ? `${historyEnrollment.student?.firstName} ${historyEnrollment.student?.lastName} with ${historyEnrollment.tutor?.firstName} ${historyEnrollment.tutor?.lastName}`
+                : ""
+            }
+          />
+        </SheetContent>
+      </Sheet>
+
       {loading && <p>Loading...</p>}
       {error && <p className="text-red-500">Error: {error}</p>}
     </>

--- a/components/admin/EnrollmentsManagement.tsx
+++ b/components/admin/EnrollmentsManagement.tsx
@@ -1561,7 +1561,7 @@ const EnrollmentList = ({
           <SessionHistoryPanel
             sessions={historySessions}
             loading={historyLoading}
-            title="Enrollment History"
+            title="SEF Enrollment History"
             subtitle={
               historyEnrollment
                 ? `${historyEnrollment.student?.firstName} ${historyEnrollment.student?.lastName} with ${historyEnrollment.tutor?.firstName} ${historyEnrollment.tutor?.lastName}`

--- a/components/admin/ScheduleManagement.tsx
+++ b/components/admin/ScheduleManagement.tsx
@@ -70,7 +70,6 @@ import {
   // checkMeetingsAvailability,
   // isMeetingAvailable,
 } from "@/lib/actions/admin.actions";
-// Add these imports at the top of the file
 import { addOneSession } from "@/lib/actions/session.server.actions";
 import { addHours, areIntervalsOverlapping } from "date-fns";
 
@@ -105,14 +104,19 @@ const Schedule = ({
   initialTutors,
   initialMeetings,
 }: any) => {
-  // changed to use useQueryCLient so cache invalidation actually propogates
   const queryClient = useQueryClient();
   const [currentWeek, setCurrentWeek] = useState(new Date());
-  const [calendarView, setCalendarView] = useState<"day" | "week" | "month">("week"); // day, week, month toggle
-  const [selectedDay, setSelectedDay] = useState(new Date()); // for day view nav
+  const [calendarView, setCalendarView] = useState<"day" | "week" | "month">("week");
+  const [selectedDay, setSelectedDay] = useState(new Date());
+
+  // keep currentWeek in sync when day view crosses week boundary
+  useEffect(() => {
+    if (calendarView === "day") setCurrentWeek(selectedDay);
+  }, [selectedDay, calendarView]);
+
   const weekEnd = endOfWeek(currentWeek).toISOString();
   const weekStart = startOfWeek(currentWeek).toISOString();
-  // query range adapts to view so month view fetches all its sessions
+  // adapts fetch range to whichever view is active
   const queryStart = calendarView === "month" ? startOfWeek(startOfMonth(currentWeek)).toISOString() : weekStart;
   const queryEnd = calendarView === "month" ? endOfWeek(endOfMonth(currentWeek)).toISOString() : weekEnd;
   // const [enrollments, setEnrollments] = useState<Enrollment[]>([]);
@@ -123,8 +127,6 @@ const Schedule = ({
   const [selectedSession, setSelectedSession] = useState<Session | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  //-----Checking Meeting Availability-----
-
   const [isCheckingMeetingAvailability, setIsCheckingMeetingAvailability] =
     useState(false);
   const [meetingAvailabilityMap, setMeetingAvailabilityMap] = useState<
@@ -132,7 +134,6 @@ const Schedule = ({
   >({});
   const [allSessions, setAllSessions] = useState<Session[]>([]);
 
-  //---------------------------------
   const initialMount = useRef(true);
   const [openStudentOptions, setOpenStudentOptions] = useState(false);
   const [openTutorOptions, setOpentTutorOptions] = useState(false);
@@ -215,7 +216,17 @@ const Schedule = ({
     queries: [
       {
         queryKey: ["sessions", queryStart, queryEnd],
-        queryFn: () => getAllSessions(queryStart, queryEnd, "date", true),
+        queryFn: async () => {
+          // weekly chunks to avoid supabase 1000 row cap
+          const fetches: Promise<Session[]>[] = [];
+          let cursor = startOfWeek(new Date(queryStart));
+          const end = new Date(queryEnd);
+          while (cursor <= end) {
+            fetches.push(getAllSessions(cursor.toISOString(), endOfWeek(cursor).toISOString(), "date", true));
+            cursor = addWeeks(cursor, 1);
+          }
+          return (await Promise.all(fetches)).flat();
+        },
       },
       {
         queryKey: ["students"],
@@ -224,10 +235,6 @@ const Schedule = ({
       {
         queryKey: ["tutors"],
         queryFn: () => getAllProfiles("Tutor"),
-      },
-      {
-        queryKey: ["enrollments", weekEnd],
-        queryFn: () => getAllActiveEnrollments(weekEnd),
       },
       {
         queryKey: ["meetings"],
@@ -240,23 +247,13 @@ const Schedule = ({
     sessionsResult,
     studentsResult,
     tutorsResult,
-    enrollmentsResult,
     meetingsResult,
   ] = query;
 
   const sessions = sessionsResult.data || [];
   const students = studentsResult.data || [];
   const tutors = tutorsResult.data || [];
-  const enrollments: Enrollment[] = useMemo(
-    () => enrollmentsResult.data ?? [],
-    [enrollmentsResult.data],
-  );
   const meetings = meetingsResult.data || [];
-  // added enrollment filtering,
-  const activeEnrollmentIds = useMemo(
-    () => new Set(enrollments.map((enrollment: Enrollment) => enrollment.id)),
-    [enrollments],
-  );
 
   let isLoading = sessionsResult.isLoading;
 
@@ -504,7 +501,7 @@ const Schedule = ({
     },
     onSettled: () => {},
   });
-  // refetch all of it before Update Week so new sessions arent created for deleted enrollments
+  // refetch enrollments first so deleted ones dont spawn sessions
   const handleUpdateWeek = async () => {
     const freshEnrollments =
       (await queryClient.fetchQuery({
@@ -515,20 +512,19 @@ const Schedule = ({
     updateWeekMutation.mutate({ enrollments: freshEnrollments });
   };
 
-  // pre-group sessions by day for perf, avoids filtering per cell
+  // groups sessions by day key so cells just do a map lookup
   const sessionsByDay = useMemo(() => {
     const map = new Map<string, Session[]>();
     for (const session of sessions) {
       if (!session?.date) continue;
       try {
-        if (!enrollmentsResult.isLoading && session.enrollmentId && !activeEnrollmentIds.has(session.enrollmentId)) continue;
         const dayKey = format(toZonedTime(parseISO(session.date), "America/New_York"), "yyyy-MM-dd");
         if (!map.has(dayKey)) map.set(dayKey, []);
         map.get(dayKey)!.push(session);
       } catch {}
     }
     return map;
-  }, [sessions, enrollmentsResult.isLoading, activeEnrollmentIds]);
+  }, [sessions]);
 
   const getValidSessionsForDay = (day: Date) => sessionsByDay.get(format(day, "yyyy-MM-dd")) || [];
 
@@ -607,25 +603,18 @@ const Schedule = ({
     setNewSession((prev) => {
       if (!prev) return {} as Session;
 
-      // Create a copy of the previous state
       const updated = { ...prev };
 
       if (name.includes(".")) {
         const [parent, child] = name.split(".");
-
-        // Type guard to ensure parent is a valid key of Session
         if (parent === "student" || parent === "tutor") {
-          // Ensure parent object exists
           const parentObj = (updated[parent] || {}) as Profile;
-
-          // Update the nested property
           updated[parent] = {
             ...parentObj,
             [child]: value,
           };
         }
       } else {
-        // Type guard to ensure name is a valid key of Session
         if (name in updated) {
           (updated as any)[name] = value;
         }
@@ -640,7 +629,6 @@ const Schedule = ({
     end: endOfWeek(currentWeek),
   });
 
-  // nav for all three views
   const goToPrevious = () => {
     if (calendarView === "day") setSelectedDay((d) => subDays(d, 1));
     else if (calendarView === "week") setCurrentWeek((w) => subWeeks(w, 1));
@@ -651,16 +639,14 @@ const Schedule = ({
     else if (calendarView === "week") setCurrentWeek((w) => addWeeks(w, 1));
     else setCurrentWeek((w) => addMonths(w, 1));
   };
-  const goToToday = () => {
-    const today = new Date();
-    setCurrentWeek(today);
-    setSelectedDay(today);
+  // jumps to a specific date, view aware
+  const goToDate = (date: Date) => {
+    setCurrentWeek(date);
+    setSelectedDay(date);
   };
 
-  // hours for the time grid, 7am to 10pm
   const HOURS = Array.from({ length: 16 }, (_, i) => i + 7);
 
-  // figure out which hour row a session falls into
   const getSessionHour = (dateStr: string) => {
     const d = toZonedTime(parseISO(dateStr), "America/New_York");
     return d.getHours();
@@ -670,14 +656,12 @@ const Schedule = ({
     return d.getMinutes();
   };
 
-  // month view helpers
   const monthStart = startOfMonth(currentWeek);
   const monthEnd = endOfMonth(currentWeek);
   const monthCalendarStart = startOfWeek(monthStart);
   const monthCalendarEnd = endOfWeek(monthEnd);
   const monthDays = eachDayOfInterval({ start: monthCalendarStart, end: monthCalendarEnd });
 
-  // memoized stats so we don't recompute every render
   const sessionStats = useMemo(() => ({
     totalSessions: sessions.length,
     tutorsInvolved: new Set(sessions.map((s) => s?.tutor?.id)).size,
@@ -685,7 +669,6 @@ const Schedule = ({
     totalStudents: students.length,
   }), [sessions, students]);
 
-  // session card used in all views
   const SessionCard = ({ session }: { session: Session }) => (
     <div
       onClick={() => {
@@ -713,7 +696,6 @@ const Schedule = ({
     </div>
   );
 
-  // header text for current view
   const getHeaderText = () => {
     if (calendarView === "day") return format(selectedDay, "EEEE, MMMM d, yyyy");
     if (calendarView === "month") return format(currentWeek, "MMMM yyyy");
@@ -724,14 +706,28 @@ const Schedule = ({
     <>
       <Toaster />
       <div className="p-6 bg-gray-50 min-h-screen">
-        {/* top bar */}
         <div className="bg-white rounded-xl shadow-sm p-4 mb-4">
           <div className="flex items-center justify-between flex-wrap gap-3">
-            {/* left side: nav */}
             <div className="flex items-center gap-2">
-              <Button variant="outline" size="sm" onClick={goToToday}>
-                Today
-              </Button>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button variant="outline" size="sm">
+                    Today
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-3" align="start">
+                  <div className="flex flex-col gap-2">
+                    <Button variant="ghost" size="sm" onClick={() => goToDate(new Date())}>Go to today</Button>
+                    <Input
+                      type="date"
+                      onChange={(e) => {
+                        const d = new Date(e.target.value + "T12:00:00");
+                        if (isValid(d)) goToDate(d);
+                      }}
+                    />
+                  </div>
+                </PopoverContent>
+              </Popover>
               <Button variant="ghost" size="icon" onClick={goToPrevious}>
                 <ChevronLeft className="h-4 w-4" />
               </Button>
@@ -743,9 +739,7 @@ const Schedule = ({
               </h2>
             </div>
 
-            {/* right side: view toggle and actions */}
             <div className="flex items-center gap-2">
-              {/* view toggle */}
               <div className="flex bg-gray-100 rounded-lg p-0.5">
                 {(["day", "week", "month"] as const).map((view) => (
                   <button
@@ -912,7 +906,6 @@ const Schedule = ({
             </div>
           </div>
 
-          {/* stats bar */}
           <div className="flex items-center gap-6 mt-3 pt-3 border-t text-sm text-gray-500">
             <span>
               <span className="font-medium text-gray-700">{sessionStats.totalSessions}</span> sessions
@@ -926,7 +919,6 @@ const Schedule = ({
           </div>
         </div>
 
-        {/* loading state */}
         {isLoading ? (
           <div className="bg-white rounded-xl shadow-sm p-10">
             <div className="text-center">
@@ -936,12 +928,10 @@ const Schedule = ({
           </div>
         ) : (
           <>
-            {/* week view, the main google calendar style grid */}
             {calendarView === "week" && (
               <div className="bg-white rounded-xl shadow-sm overflow-hidden">
-                {/* day headers */}
                 <div className="grid grid-cols-[60px_repeat(7,1fr)] border-b">
-                  <div className="border-r" /> {/* spacer for time col */}
+                  <div className="border-r" />
                   {weekDays.map((day) => (
                     <div
                       key={day.toISOString()}
@@ -963,7 +953,6 @@ const Schedule = ({
                   ))}
                 </div>
 
-                {/* time grid - no scroll, all sessions visible */}
                 <div className="grid grid-cols-[60px_repeat(7,1fr)]">
                   {HOURS.map((hour) => (
                     <React.Fragment key={hour}>
@@ -996,11 +985,9 @@ const Schedule = ({
               </div>
             )}
 
-            {/* day view */}
             {calendarView === "day" && (
               <div className="bg-white rounded-xl shadow-sm overflow-hidden">
                 <div className="grid grid-cols-[60px_1fr]">
-                  {/* header */}
                   <div className="border-r border-b" />
                   <div className={cn("py-3 px-4 border-b", isToday(selectedDay) && "bg-blue-50")}>
                     <p className="text-xs text-gray-500 uppercase">{format(selectedDay, "EEEE")}</p>
@@ -1036,10 +1023,8 @@ const Schedule = ({
               </div>
             )}
 
-            {/* month view */}
             {calendarView === "month" && (
               <div className="bg-white rounded-xl shadow-sm overflow-hidden">
-                {/* day of week headers */}
                 <div className="grid grid-cols-7 border-b">
                   {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((d) => (
                     <div key={d} className="text-center py-2 text-xs font-medium text-gray-500 uppercase border-r last:border-r-0">
@@ -1047,7 +1032,6 @@ const Schedule = ({
                     </div>
                   ))}
                 </div>
-                {/* calendar grid */}
                 <div className="grid grid-cols-7">
                   {monthDays.map((day) => {
                     const daySessions = getValidSessionsForDay(day);
@@ -1098,7 +1082,6 @@ const Schedule = ({
           </>
         )}
 
-        {/* session details modal, keeping all existing fields */}
         <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
           <DialogContent>
             <DialogHeader>

--- a/components/admin/ScheduleManagement.tsx
+++ b/components/admin/ScheduleManagement.tsx
@@ -719,7 +719,7 @@ const Schedule = ({
       <div className="p-6 bg-gray-50 min-h-screen">
         <div className="bg-white rounded-xl shadow-sm p-4 mb-4">
           <div className="flex items-center justify-between flex-wrap gap-3">
-            <div className="flex items-center gap-2">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
               <Popover>
                 <PopoverTrigger asChild>
                   <Button variant="outline" size="sm">
@@ -745,12 +745,12 @@ const Schedule = ({
               <Button variant="ghost" size="icon" onClick={goToNext}>
                 <ChevronRight className="h-4 w-4" />
               </Button>
-              <h2 className="text-lg font-semibold text-gray-800 ml-2">
+              <h2 className="ml-2 min-w-0 text-base font-semibold text-gray-800 sm:text-lg">
                 {getHeaderText()}
               </h2>
             </div>
 
-            <div className="flex items-center gap-2">
+            <div className="flex w-full flex-wrap items-center gap-2 md:w-auto md:justify-end">
               <div className="flex bg-gray-100 rounded-lg p-0.5">
                 {(["day", "week", "month"] as const).map((view) => (
                   <button
@@ -940,58 +940,61 @@ const Schedule = ({
         ) : (
           <>
             {calendarView === "week" && (
-              <div className="bg-white rounded-xl shadow-sm overflow-hidden">
-                <div className="grid grid-cols-[60px_repeat(7,1fr)] border-b">
-                  <div className="border-r" />
-                  {weekDays.map((day) => (
-                    <div
-                      key={day.toISOString()}
-                      className={cn(
-                        "text-center py-3 border-r last:border-r-0",
-                        isToday(day) && "bg-blue-50"
-                      )}
-                    >
-                      <p className="text-xs text-gray-500 uppercase">{format(day, "EEE")}</p>
-                      <p className={cn(
-                        "text-lg font-semibold",
-                        isToday(day)
-                          ? "bg-blue-600 text-white rounded-full w-8 h-8 flex items-center justify-center mx-auto"
-                          : "text-gray-800"
-                      )}>
-                        {format(day, "d")}
-                      </p>
-                    </div>
-                  ))}
-                </div>
-
-                <div className="grid grid-cols-[60px_repeat(7,1fr)]">
-                  {HOURS.map((hour) => (
-                    <React.Fragment key={hour}>
-                      <div className="border-r border-b min-h-[36px] flex items-start justify-end pr-2 pt-1">
-                        <span className="text-[11px] text-gray-400">
-                          {hour === 0 ? "12:00 AM" : hour < 12 ? `${hour}:00 AM` : hour === 12 ? "12:00 PM" : `${hour - 12}:00 PM`}
-                        </span>
+              <div className="overflow-x-auto rounded-xl bg-white shadow-sm">
+                <div className="min-w-[960px] overflow-hidden rounded-xl">
+                  <div className="grid grid-cols-[56px_repeat(7,minmax(128px,1fr))] border-b">
+                    <div className="border-r" />
+                    {weekDays.map((day) => (
+                      <div
+                        key={day.toISOString()}
+                        className={cn(
+                          "min-w-0 border-r py-3 text-center last:border-r-0",
+                          isToday(day) && "bg-blue-50"
+                        )}
+                      >
+                        <p className="text-xs uppercase text-gray-500">{format(day, "EEE")}</p>
+                        <p className={cn(
+                          "mx-auto flex h-8 w-8 items-center justify-center rounded-full text-lg font-semibold",
+                          isToday(day)
+                            ? "bg-blue-600 text-white"
+                            : "text-gray-800"
+                        )}>
+                          {format(day, "d")}
+                        </p>
                       </div>
-                      {weekDays.map((day) => {
-                        const daySessions = getValidSessionsForDay(day).filter(
-                          (s) => getSessionHour(s.date) === hour
-                        );
-                        return (
-                          <div
-                            key={`${day.toISOString()}-${hour}`}
-                            className={cn(
-                              "border-r border-b last:border-r-0 min-h-[36px] p-[2px] space-y-0.5",
-                              isToday(day) && "bg-blue-50/30"
-                            )}
-                          >
-                            {daySessions.map((session) => (
-                              <SessionCard key={session.id} session={session} />
-                            ))}
-                          </div>
-                        );
-                      })}
-                    </React.Fragment>
-                  ))}
+                    ))}
+                  </div>
+
+                  <div className="grid grid-cols-[56px_repeat(7,minmax(128px,1fr))]">
+                    {HOURS.map((hour) => (
+                      <React.Fragment key={hour}>
+                        <div className="flex min-h-[36px] items-start justify-end border-r border-b pr-2 pt-1">
+                          <span className="text-[11px] text-gray-400">
+                            {hour === 0 ? "12:00 AM" : hour < 12 ? `${hour}:00 AM` : hour === 12 ? "12:00 PM" : `${hour - 12}:00 PM`}
+                          </span>
+                        </div>
+                        {weekDays.map((day) => {
+                          const daySessions = getValidSessionsForDay(day).filter(
+                            (s) => getSessionHour(s.date) === hour
+                          );
+                          return (
+                            <div
+                              key={`${day.toISOString()}-${hour}`}
+                              className={cn(
+                                "min-w-0 space-y-0.5 border-r border-b p-[2px] last:border-r-0",
+                                "min-h-[36px]",
+                                isToday(day) && "bg-blue-50/30"
+                              )}
+                            >
+                              {daySessions.map((session) => (
+                                <SessionCard key={session.id} session={session} />
+                              ))}
+                            </div>
+                          );
+                        })}
+                      </React.Fragment>
+                    ))}
+                  </div>
                 </div>
               </div>
             )}
@@ -1035,58 +1038,60 @@ const Schedule = ({
             )}
 
             {calendarView === "month" && (
-              <div className="bg-white rounded-xl shadow-sm overflow-hidden">
-                <div className="grid grid-cols-7 border-b">
-                  {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((d) => (
-                    <div key={d} className="text-center py-2 text-xs font-medium text-gray-500 uppercase border-r last:border-r-0">
-                      {d}
-                    </div>
-                  ))}
-                </div>
-                <div className="grid grid-cols-7">
-                  {monthDays.map((day) => {
-                    const daySessions = getValidSessionsForDay(day);
-                    return (
-                      <div
-                        key={day.toISOString()}
-                        className={cn(
-                          "border-r border-b last:border-r-0 min-h-[100px] p-1",
-                          !isSameMonth(day, currentWeek) && "bg-gray-50 opacity-50",
-                          isToday(day) && "bg-blue-50"
-                        )}
-                      >
-                        <p className={cn(
-                          "text-xs font-medium mb-1",
-                          isToday(day)
-                            ? "bg-blue-600 text-white rounded-full w-5 h-5 flex items-center justify-center"
-                            : "text-gray-600"
-                        )}>
-                          {format(day, "d")}
-                        </p>
-                        <div className="space-y-0.5">
-                          {daySessions.map((session) => (
-                            <div
-                              key={session.id}
-                              onClick={() => {
-                                setSelectedSession(session);
-                                setIsModalOpen(true);
-                              }}
-                              className={cn(
-                                "text-[10px] px-1 py-0.5 rounded truncate cursor-pointer",
-                                session.status === "Complete"
-                                  ? "bg-green-100 text-green-800"
-                                  : session.status === "Cancelled"
-                                    ? "bg-red-100 text-red-800"
-                                    : "bg-blue-100 text-blue-800"
-                              )}
-                            >
-                              {session.tutor?.firstName} / {session.student?.firstName}
-                            </div>
-                          ))}
-                        </div>
+              <div className="overflow-x-auto rounded-xl bg-white shadow-sm">
+                <div className="min-w-[960px] overflow-hidden rounded-xl">
+                  <div className="grid grid-cols-7 border-b">
+                    {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((d) => (
+                      <div key={d} className="border-r py-2 text-center text-xs font-medium uppercase text-gray-500 last:border-r-0">
+                        {d}
                       </div>
-                    );
-                  })}
+                    ))}
+                  </div>
+                  <div className="grid grid-cols-7">
+                    {monthDays.map((day) => {
+                      const daySessions = getValidSessionsForDay(day);
+                      return (
+                        <div
+                          key={day.toISOString()}
+                          className={cn(
+                            "min-h-[100px] min-w-0 border-r border-b p-1 last:border-r-0",
+                            !isSameMonth(day, currentWeek) && "bg-gray-50 opacity-50",
+                            isToday(day) && "bg-blue-50"
+                          )}
+                        >
+                          <p className={cn(
+                            "mb-1 flex h-5 w-5 items-center justify-center rounded-full text-xs font-medium",
+                            isToday(day)
+                              ? "bg-blue-600 text-white"
+                              : "text-gray-600"
+                          )}>
+                            {format(day, "d")}
+                          </p>
+                          <div className="space-y-0.5">
+                            {daySessions.map((session) => (
+                              <div
+                                key={session.id}
+                                onClick={() => {
+                                  setSelectedSession(session);
+                                  setIsModalOpen(true);
+                                }}
+                                className={cn(
+                                  "cursor-pointer truncate rounded px-1 py-0.5 text-[10px]",
+                                  session.status === "Complete"
+                                    ? "bg-green-100 text-green-800"
+                                    : session.status === "Cancelled"
+                                      ? "bg-red-100 text-red-800"
+                                      : "bg-blue-100 text-blue-800"
+                                )}
+                              >
+                                {session.tutor?.firstName} / {session.student?.firstName}
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
                 </div>
               </div>
             )}

--- a/components/admin/ScheduleManagement.tsx
+++ b/components/admin/ScheduleManagement.tsx
@@ -5,18 +5,29 @@ import {
   format,
   startOfWeek,
   endOfWeek,
+  startOfMonth,
+  endOfMonth,
   eachDayOfInterval,
   addWeeks,
   subWeeks,
+  addDays,
+  subDays,
+  addMonths,
+  subMonths,
   parseISO,
   isAfter,
+  isSameDay,
+  isSameMonth,
+  isToday,
   isValid,
   previousDay,
+  getDay,
 } from "date-fns";
 import { toZonedTime } from "date-fns-tz";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import ProfileSelector from "@/components/ui/profile-selector";
 import {
   Command,
@@ -81,7 +92,6 @@ import { Textarea } from "../ui/textarea";
 import { boolean } from "zod";
 import { checkAvailableMeeting } from "@/lib/actions/meeting.actions";
 import { getAllActiveEnrollments } from "@/lib/actions/enrollment.actions";
-import { getEnrollmentsWithMissingSEF } from "@/lib/actions/enrollment.server.actions";
 import { useMutation, useQueries, useQuery } from "@tanstack/react-query";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -98,8 +108,13 @@ const Schedule = ({
   // changed to use useQueryCLient so cache invalidation actually propogates
   const queryClient = useQueryClient();
   const [currentWeek, setCurrentWeek] = useState(new Date());
+  const [calendarView, setCalendarView] = useState<"day" | "week" | "month">("week"); // day, week, month toggle
+  const [selectedDay, setSelectedDay] = useState(new Date()); // for day view nav
   const weekEnd = endOfWeek(currentWeek).toISOString();
   const weekStart = startOfWeek(currentWeek).toISOString();
+  // query range adapts to view so month view fetches all its sessions
+  const queryStart = calendarView === "month" ? startOfWeek(startOfMonth(currentWeek)).toISOString() : weekStart;
+  const queryEnd = calendarView === "month" ? endOfWeek(endOfMonth(currentWeek)).toISOString() : weekEnd;
   // const [enrollments, setEnrollments] = useState<Enrollment[]>([]);
   // const [meetings, setMeetings] = useState<Meeting[]>([]);
   // const [students, setStudents] = useState<Profile[]>([]);
@@ -199,8 +214,8 @@ const Schedule = ({
   const query = useQueries({
     queries: [
       {
-        queryKey: ["sessions", weekStart, weekEnd],
-        queryFn: () => getAllSessions(weekStart, weekEnd, "date", true),
+        queryKey: ["sessions", queryStart, queryEnd],
+        queryFn: () => getAllSessions(queryStart, queryEnd, "date", true),
       },
       {
         queryKey: ["students"],
@@ -472,9 +487,7 @@ const Schedule = ({
       // return { prevSessions };
     },
     onSuccess: (newSessions: Session[]) => {
-      queryClient.invalidateQueries({
-        queryKey: ["sessions", weekStart, weekEnd],
-      });
+      queryClient.invalidateQueries({ queryKey: ["sessions"] }); // broad invalidation catches any date range
       toast.success(`${newSessions.length} new sessions added successfully`);
     },
     onError: (error: any, _, context) => {
@@ -502,45 +515,35 @@ const Schedule = ({
     updateWeekMutation.mutate({ enrollments: freshEnrollments });
   };
 
-  // Filter sessions with valid dates for display
-  const getValidSessionsForDay = (day: Date) => {
-    return sessions.filter((session) => {
-      if (!session?.date) return false;
+  // pre-group sessions by day for perf, avoids filtering per cell
+  const sessionsByDay = useMemo(() => {
+    const map = new Map<string, Session[]>();
+    for (const session of sessions) {
+      if (!session?.date) continue;
       try {
-        if (
-          !enrollmentsResult.isLoading &&
-          session.enrollmentId &&
-          !activeEnrollmentIds.has(session.enrollmentId)
-        ) {
-          return false;
-        }
-        return (
-          format(
-            toZonedTime(parseISO(session.date), "America/New_York"),
-            "yyyy-MM-dd",
-          ) === format(day, "yyyy-MM-dd")
-        );
-      } catch (error) {
-        console.error("Error filtering session:", error);
-        return false;
-      }
-    });
-  };
+        if (!enrollmentsResult.isLoading && session.enrollmentId && !activeEnrollmentIds.has(session.enrollmentId)) continue;
+        const dayKey = format(toZonedTime(parseISO(session.date), "America/New_York"), "yyyy-MM-dd");
+        if (!map.has(dayKey)) map.set(dayKey, []);
+        map.get(dayKey)!.push(session);
+      } catch {}
+    }
+    return map;
+  }, [sessions, enrollmentsResult.isLoading, activeEnrollmentIds]);
+
+  const getValidSessionsForDay = (day: Date) => sessionsByDay.get(format(day, "yyyy-MM-dd")) || [];
 
   const removeSessionMutation = useMutation({
     mutationFn: (sessionId: string) => removeSession(sessionId),
     onMutate: async (sessionId: string) => {
-      await queryClient.cancelQueries({
-        queryKey: ["sessions", weekStart, weekEnd],
-      });
+      await queryClient.cancelQueries({ queryKey: ["sessions"] });
       const prevSessions = queryClient.getQueryData<Session[]>([
         "sessions",
-        weekStart,
-        weekEnd,
+        queryStart,
+        queryEnd,
       ]);
 
       queryClient.setQueryData(
-        ["sessions", weekStart, weekEnd],
+        ["sessions", queryStart, queryEnd],
         (sessions: Session[] | undefined) =>
           sessions
             ? sessions.filter((session) => session.id !== sessionId)
@@ -556,7 +559,7 @@ const Schedule = ({
     onError: (error: any, sessionId, context) => {
       if (context) {
         queryClient.setQueryData(
-          ["sessions", weekStart, weekEnd],
+          ["sessions", queryStart, queryEnd],
           context.prevSessions,
         );
       }
@@ -564,9 +567,7 @@ const Schedule = ({
       toast.error("Failed to remove session");
     },
     onSettled: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["sessions", weekStart, weekEnd],
-      });
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
     },
   });
 
@@ -579,7 +580,7 @@ const Schedule = ({
       await updateSession(updatedSession);
       toast.success("Session updated successfully");
       setIsModalOpen(false);
-      fetchSessions(weekStart, weekEnd);
+      fetchSessions(queryStart, queryEnd);
     } catch (error) {
       console.error("Failed to update session:", error);
       toast.error("Failed to update session");
@@ -639,378 +640,465 @@ const Schedule = ({
     end: endOfWeek(currentWeek),
   });
 
-  const goToPreviousWeek = () =>
-    setCurrentWeek((prevWeek) => subWeeks(prevWeek, 1));
-  const goToNextWeek = () =>
-    setCurrentWeek((prevWeek) => addWeeks(prevWeek, 1));
-
-  const getEnrollmentProgress = () => {
-    const totalStudents = students.length;
-    const studentsThisWeek = new Set(
-      sessions.map((session) => session?.student?.id),
-    ).size;
-    return { totalStudents, studentsThisWeek };
+  // nav for all three views
+  const goToPrevious = () => {
+    if (calendarView === "day") setSelectedDay((d) => subDays(d, 1));
+    else if (calendarView === "week") setCurrentWeek((w) => subWeeks(w, 1));
+    else setCurrentWeek((w) => subMonths(w, 1));
+  };
+  const goToNext = () => {
+    if (calendarView === "day") setSelectedDay((d) => addDays(d, 1));
+    else if (calendarView === "week") setCurrentWeek((w) => addWeeks(w, 1));
+    else setCurrentWeek((w) => addMonths(w, 1));
+  };
+  const goToToday = () => {
+    const today = new Date();
+    setCurrentWeek(today);
+    setSelectedDay(today);
   };
 
-  // calc total and unique sessions for the week
-  const getSessionStatistics = () => {
-    const totalSessions = sessions.length;
-    const tutorsInvolved = new Set(
-      sessions.map((session) => session?.tutor?.id),
-    ).size;
-    return { totalSessions, tutorsInvolved };
+  // hours for the time grid, 7am to 10pm
+  const HOURS = Array.from({ length: 16 }, (_, i) => i + 7);
+
+  // figure out which hour row a session falls into
+  const getSessionHour = (dateStr: string) => {
+    const d = toZonedTime(parseISO(dateStr), "America/New_York");
+    return d.getHours();
+  };
+  const getSessionMinutes = (dateStr: string) => {
+    const d = toZonedTime(parseISO(dateStr), "America/New_York");
+    return d.getMinutes();
   };
 
-  const handleGetMissingSEF = async () => {
-    try {
-      await getEnrollmentsWithMissingSEF();
-      toast.success("Printed to console");
-    } catch (error) {
-      console.error(error);
-      toast.error("Please view Dev Console for error");
-    }
+  // month view helpers
+  const monthStart = startOfMonth(currentWeek);
+  const monthEnd = endOfMonth(currentWeek);
+  const monthCalendarStart = startOfWeek(monthStart);
+  const monthCalendarEnd = endOfWeek(monthEnd);
+  const monthDays = eachDayOfInterval({ start: monthCalendarStart, end: monthCalendarEnd });
+
+  // memoized stats so we don't recompute every render
+  const sessionStats = useMemo(() => ({
+    totalSessions: sessions.length,
+    tutorsInvolved: new Set(sessions.map((s) => s?.tutor?.id)).size,
+    studentsThisWeek: new Set(sessions.map((s) => s?.student?.id)).size,
+    totalStudents: students.length,
+  }), [sessions, students]);
+
+  // session card used in all views
+  const SessionCard = ({ session }: { session: Session }) => (
+    <div
+      onClick={() => {
+        setSelectedSession(session);
+        setIsModalOpen(true);
+      }}
+      className={cn(
+        "rounded-md px-2 py-1 text-xs cursor-pointer border-l-2 truncate hover:shadow-md transition-shadow",
+        session.status === "Complete"
+          ? "bg-green-50 border-l-green-500 text-green-900"
+          : session.status === "Cancelled"
+            ? "bg-red-50 border-l-red-500 text-red-900"
+            : "bg-blue-50 border-l-blue-500 text-blue-900"
+      )}
+    >
+      <p className="font-medium truncate">
+        {session.tutor?.firstName} {session.tutor?.lastName}
+      </p>
+      <p className="truncate text-[11px] opacity-80">
+        {session.student?.firstName} {session.student?.lastName}
+      </p>
+      <p className="text-[10px] opacity-60">
+        {getSessionTimespan(session.date, session.duration)}
+      </p>
+    </div>
+  );
+
+  // header text for current view
+  const getHeaderText = () => {
+    if (calendarView === "day") return format(selectedDay, "EEEE, MMMM d, yyyy");
+    if (calendarView === "month") return format(currentWeek, "MMMM yyyy");
+    return `${format(weekDays[0], "MMM d")} - ${format(weekDays[6], "MMM d, yyyy")}`;
   };
 
   return (
     <>
       <Toaster />
-      <div className="p-8 bg-gray-100 min-h-screen">
-        <h1 className="text-3xl font-bold mb-6 text-left text-gray-800">
-          Schedule
-        </h1>
+      <div className="p-6 bg-gray-50 min-h-screen">
+        {/* top bar */}
+        <div className="bg-white rounded-xl shadow-sm p-4 mb-4">
+          <div className="flex items-center justify-between flex-wrap gap-3">
+            {/* left side: nav */}
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" onClick={goToToday}>
+                Today
+              </Button>
+              <Button variant="ghost" size="icon" onClick={goToPrevious}>
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <Button variant="ghost" size="icon" onClick={goToNext}>
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+              <h2 className="text-lg font-semibold text-gray-800 ml-2">
+                {getHeaderText()}
+              </h2>
+            </div>
 
-        <div className="bg-white rounded-lg shadow-sm p-6 mb-6">
-          <div className="flex justify-between items-center mb-6">
-            <Button
-              variant="outline"
-              onClick={goToPreviousWeek}
-              className="flex items-center"
-            >
-              <ChevronLeft className="w-5 h-5 mr-2" /> Previous Week
-            </Button>
-            <h2 className="text-xl font-semibold text-gray-700">
-              {format(weekDays[0], "MMMM d, yyyy")} -{" "}
-              {format(weekDays[6], "MMMM d, yyyy")}
-            </h2>
-            <Button
-              variant="outline"
-              onClick={goToNextWeek}
-              className="flex items-center"
-            >
-              Next Week <ChevronRight className="w-5 h-5 ml-2" />
-            </Button>
+            {/* right side: view toggle and actions */}
+            <div className="flex items-center gap-2">
+              {/* view toggle */}
+              <div className="flex bg-gray-100 rounded-lg p-0.5">
+                {(["day", "week", "month"] as const).map((view) => (
+                  <button
+                    key={view}
+                    onClick={() => setCalendarView(view)}
+                    className={cn(
+                      "px-3 py-1.5 text-sm font-medium rounded-md transition-colors capitalize",
+                      calendarView === view
+                        ? "bg-white shadow-sm text-gray-900"
+                        : "text-gray-500 hover:text-gray-700"
+                    )}
+                  >
+                    {view}
+                  </button>
+                ))}
+              </div>
+
+              <Button
+                onClick={handleUpdateWeek}
+                disabled={isLoading}
+                size="sm"
+                className="bg-connect-me-blue-3 hover:bg-connect-me-blue-4"
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                    Loading
+                  </>
+                ) : (
+                  "Update Week"
+                )}
+              </Button>
+
+              <Dialog>
+                <DialogTrigger asChild>
+                  <Button size="sm" className="bg-connect-me-blue-4 hover:bg-connect-me-blue-5">
+                    Add Session
+                  </Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Add Session</DialogTitle>
+                  </DialogHeader>
+                  <ScrollArea className="pr-4">
+                    <div className="grid gap-4 py-4">
+                      <ProfileSelector
+                        label="Student"
+                        profiles={students}
+                        selectedId={selectedStudentId}
+                        onSelect={(id) => {
+                          setSelectedStudentId(id);
+                          handleInputChange({ target: { name: "student.id", value: id } });
+                        }}
+                        placeholder="Select a student"
+                      />
+                      <ProfileSelector
+                        label="Tutor"
+                        profiles={tutors}
+                        selectedId={selectedTutorId}
+                        onSelect={(id) => {
+                          setSelectedTutorId(id);
+                          handleInputChange({ target: { name: "tutor.id", value: id } });
+                        }}
+                        placeholder="Select a tutor"
+                      />
+                      <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="startDate" className="text-right">Date</Label>
+                        <Input
+                          id="startDate"
+                          name="startDate"
+                          type="datetime-local"
+                          defaultValue={formatDateForInput(newSession.date)}
+                          onBlur={async (e) => {
+                            const scheduledDate = new Date(e.target.value);
+                            const updatedSession: Partial<Session> = {
+                              ...newSession,
+                              date: scheduledDate.toISOString(),
+                            };
+                            await checkMeetingAvailabilites(updatedSession as Session);
+                            setNewSession(updatedSession);
+                          }}
+                          disabled={isCheckingMeetingAvailability}
+                          className="col-span-3"
+                        />
+                      </div>
+                      <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="duration" className="text-right">Duration</Label>
+                        <div className="col-span-3">
+                          <Select
+                            onValueChange={(value) => {
+                              const duration = parseFloat(value);
+                              const updatedSession: Partial<Session> = { ...newSession, duration };
+                              checkMeetingAvailabilites(updatedSession as Session);
+                              setNewSession(updatedSession);
+                            }}
+                          >
+                            <SelectTrigger className="w-full">
+                              <SelectValue placeholder="Select a time duration" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectGroup>
+                                <SelectLabel>Duration</SelectLabel>
+                                {Array.from({ length: 12 }, (_, i) => (i + 1) * 0.25).map((duration) => {
+                                  const minutes = (duration % 1) * 60;
+                                  const hours = Math.floor(duration);
+                                  return (
+                                    <SelectItem key={duration} value={duration.toString()}>
+                                      {hours} {hours > 1 ? "hours" : "hour"} {minutes} minutes
+                                    </SelectItem>
+                                  );
+                                })}
+                              </SelectGroup>
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      </div>
+                      <div className="grid grid-cols-4 items-center gap-4">
+                        <Label className="text-right">Meeting Link</Label>
+                        <div className="col-span-3">
+                          <Select
+                            value={newSession?.meeting?.id || ""}
+                            onValueChange={async (value) => {
+                              setNewSession({ ...newSession, meeting: await getMeeting(value) });
+                            }}
+                          >
+                            <SelectTrigger>
+                              <SelectValue>
+                                {newSession?.meeting?.name || "Select a meeting"}
+                              </SelectValue>
+                            </SelectTrigger>
+                            <SelectContent>
+                              {meetings.map((meeting) => (
+                                <SelectItem key={meeting.id} value={meeting.id} className="flex items-center justify-between">
+                                  <span>{meeting.name}</span>
+                                  <Circle
+                                    className={`w-2 h-2 ml-2 ${
+                                      meetingAvailabilityMap[meeting.id] ? "text-green-500" : "text-red-500"
+                                    } fill-current`}
+                                  />
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      </div>
+                      <Button
+                        onClick={handleAddSession}
+                        disabled={isCheckingMeetingAvailability}
+                        className="bg-connect-me-blue-3"
+                      >
+                        {isCheckingMeetingAvailability ? (
+                          <>
+                            Checking Meeting Availability
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          </>
+                        ) : (
+                          "Add Session"
+                        )}
+                      </Button>
+                    </div>
+                  </ScrollArea>
+                </DialogContent>
+              </Dialog>
+            </div>
           </div>
 
-          <Button
-            onClick={handleUpdateWeek}
-            disabled={isLoading}
-            className="mb-4 bg-connect-me-blue-2"
-          >
-            {isLoading ? (
-              <>
-                Loading Sessions{"  "}
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              </>
-            ) : (
-              "Update Week"
-            )}
-          </Button>
-          <Dialog>
-            <DialogTrigger asChild>
-              <Button className="mx-4 bg-connect-me-blue-3">Add Session</Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Add Session</DialogTitle>
-              </DialogHeader>
-
-              <ScrollArea className="pr-4">
-                {" "}
-                <div className="grid gap-4 py-4">
-                  <ProfileSelector
-                    label="Student"
-                    profiles={students}
-                    selectedId={selectedStudentId}
-                    onSelect={(id) => {
-                      setSelectedStudentId(id);
-                      handleInputChange({
-                        target: { name: "student.id", value: id },
-                      });
-                    }}
-                    placeholder="Select a student"
-                  />
-
-                  <ProfileSelector
-                    label="Tutor"
-                    profiles={tutors}
-                    selectedId={selectedTutorId}
-                    onSelect={(id) => {
-                      setSelectedTutorId(id);
-                      handleInputChange({
-                        target: { name: "tutor.id", value: id },
-                      });
-                    }}
-                    placeholder="Select a tutor"
-                  />
-                  <div className="grid grid-cols-4 items-center gap-4">
-                    <Label htmlFor="startDate" className="text-right">
-                      Date
-                    </Label>
-                    <Input
-                      id="startDate"
-                      name="startDate"
-                      type="datetime-local"
-                      defaultValue={formatDateForInput(newSession.date)}
-                      onBlur={async (e) => {
-                        const scheduledDate = new Date(e.target.value);
-                        const updatedSession: Partial<Session> = {
-                          ...newSession,
-                          date: scheduledDate.toISOString(),
-                        };
-                        await checkMeetingAvailabilites(
-                          updatedSession as Session,
-                        );
-                        setNewSession(updatedSession);
-                      }}
-                      disabled={isCheckingMeetingAvailability}
-                      className="col-span-3"
-                    />
-                  </div>
-                  <div className="grid grid-cols-4 items-center gap-4">
-                    <Label htmlFor="duration" className="text-right">
-                      Duration
-                    </Label>{" "}
-                    <div className="col-span-3">
-                      {" "}
-                      <Select
-                        onValueChange={(value) => {
-                          const duration = parseFloat(value);
-                          const updatedSession: Partial<Session> = {
-                            ...newSession,
-                            duration: duration,
-                          };
-                          checkMeetingAvailabilites(updatedSession as Session);
-                          setNewSession(updatedSession);
-                        }}
-                      >
-                        <SelectTrigger className="w-full">
-                          <SelectValue placeholder="Select a time duration" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectGroup>
-                            <SelectLabel>Duration</SelectLabel>
-                            {Array.from(
-                              { length: 12 },
-                              (_, i) => (i + 1) * 0.25,
-                            ).map((duration) => {
-                              const minutes = (duration % 1) * 60;
-                              const hours = Math.floor(duration);
-
-                              return (
-                                <SelectItem
-                                  key={duration}
-                                  value={duration.toString()}
-                                >
-                                  {hours} {hours > 1 ? "hours" : "hour"}{" "}
-                                  {minutes} minutes
-                                </SelectItem>
-                              );
-                            })}
-                          </SelectGroup>
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  </div>
-                  <div className="grid grid-cols-4 items-center gap-4">
-                    <Label htmlFor="" className="text-right">
-                      Meeting Link
-                    </Label>
-                    <div className="col-span-3">
-                      {" "}
-                      <Select
-                        value={newSession?.meeting?.id || ""}
-                        onOpenChange={(open) => {
-                          if (open && newSession) {
-                          }
-                        }}
-                        onValueChange={async (value) => {
-                          setNewSession({
-                            ...newSession,
-                            meeting: await getMeeting(value),
-                          });
-                        }}
-                      >
-                        <SelectTrigger>
-                          <SelectValue>
-                            {newSession?.meeting?.name || "Select a meeting"}
-                          </SelectValue>
-                        </SelectTrigger>
-                        <SelectContent>
-                          {meetings.map((meeting) => (
-                            <SelectItem
-                              key={meeting.id}
-                              value={meeting.id}
-                              className="flex items-center justify-between"
-                            >
-                              <span>{meeting.name}</span>
-                              <Circle
-                                className={`w-2 h-2 ml-2 ${
-                                  meetingAvailabilityMap[meeting.id]
-                                    ? "text-green-500"
-                                    : "text-red-500"
-                                } fill-current`}
-                              />
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  </div>
-
-                  {/* Other form fields */}
-                  <Button
-                    onClick={handleAddSession}
-                    disabled={isCheckingMeetingAvailability}
-                    className="bg-connect-me-blue-3"
-                  >
-                    {isCheckingMeetingAvailability ? (
-                      <>
-                        Checking Meeting Availability
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      </>
-                    ) : (
-                      "Add Session"
-                    )}
-                  </Button>
-                </div>
-              </ScrollArea>
-            </DialogContent>
-          </Dialog>
-          <Button
-            className="bg-connect-me-blue-4"
-            onClick={() => handleGetMissingSEF()}
-          >
-            Function Tester
-          </Button>
-
-          {isLoading ? (
-            <div className="text-center py-10">
-              <Calendar className="w-10 h-10 animate-spin mx-auto text-blue-500" />
-              <p className="mt-4 text-gray-600">Loading sessions...</p>
-            </div>
-          ) : (
-            <div className="grid grid-cols-7 gap-2">
-              {weekDays.map((day) => (
-                <div
-                  key={day.toISOString()}
-                  className="border rounded-lg px-2 py-3 bg-gray-50"
-                >
-                  <h3 className="font-semibold mb-2 text-gray-700">
-                    {format(day, "EEEE")}
-                  </h3>
-                  <p className="text-sm mb-4 text-gray-500">
-                    {format(day, "MMM d")}
-                  </p>
-                  {getValidSessionsForDay(day).map((session) => (
-                    <Card
-                      onClick={() => {
-                        setSelectedSession(session);
-                        setIsModalOpen(true);
-                      }}
-                      key={session.id}
-                      className={`hover:cursor-pointer hover:shadow-md mb-2 ${
-                        session.status === "Complete"
-                          ? "bg-green-500/10 border-2"
-                          : session.status === "Cancelled"
-                            ? "bg-red-500/10 border-2"
-                            : "bg-white"
-                      }`}
-                    >
-                      <CardContent className="p-3">
-                        <p className="text-xs font-semibold">
-                          {session.tutor?.firstName} {session.tutor?.lastName}
-                        </p>
-                        <p className="text-xs font-normal">
-                          {session?.student?.firstName}{" "}
-                          {session?.student?.lastName}
-                        </p>
-                        <p className="text-xs text-gray-500">
-                          {session.summary}
-                        </p>
-                        <p className="text-xs text-gray-500">
-                          {getSessionTimespan(session.date, session.duration)}{" "}
-                          EDT
-                        </p>
-                        <div
-                          className={`text-xs font-medium px-2 py-1 rounded-lg mt-1 border ${
-                            session.meeting != null
-                              ? "border-green-300 text-green-700"
-                              : "bg-red-100 text-red-700"
-                          }`}
-                        >
-                          {session?.meeting != null &&
-                          session?.meeting.name != null
-                            ? session?.meeting.name
-                            : "No Meeting Link"}
-                        </div>
-
-                        <Button
-                          className="hidden mt-2 w-full text-xs h-6"
-                          onClick={() => {
-                            setSelectedSession(session);
-                            setIsModalOpen(true);
-                          }}
-                          variant="outline"
-                        >
-                          View Details
-                        </Button>
-                      </CardContent>
-                    </Card>
-                  ))}
-                  {sessions.filter(
-                    (session) =>
-                      session?.date &&
-                      format(parseISO(session.date), "yyyy-MM-dd") ===
-                        format(day, "yyyy-MM-dd"),
-                  ).length === 0 && (
-                    <p className="text-sm text-gray-400 text-center">
-                      No sessions
-                    </p>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
+          {/* stats bar */}
+          <div className="flex items-center gap-6 mt-3 pt-3 border-t text-sm text-gray-500">
+            <span>
+              <span className="font-medium text-gray-700">{sessionStats.totalSessions}</span> sessions
+            </span>
+            <span>
+              <span className="font-medium text-gray-700">{sessionStats.tutorsInvolved}</span> tutors
+            </span>
+            <span>
+              <span className="font-medium text-gray-700">{sessionStats.studentsThisWeek}</span> / {sessionStats.totalStudents} students
+            </span>
+          </div>
         </div>
 
-        <div>
-          <h3 className="text-3xl font-bold mb-6 text-left text-gray-800">
-            Enrollment Progress
-          </h3>
-          <Card className="mb-6">
-            <CardContent className="p-6">
-              <div className="grid grid-cols-4 gap-4">
-                <div>
-                  <p className="font-medium">Total Students:</p>
-                  <p>{getEnrollmentProgress().totalStudents}</p>
+        {/* loading state */}
+        {isLoading ? (
+          <div className="bg-white rounded-xl shadow-sm p-10">
+            <div className="text-center">
+              <Calendar className="w-8 h-8 animate-spin mx-auto text-blue-500" />
+              <p className="mt-3 text-gray-500 text-sm">Loading sessions...</p>
+            </div>
+          </div>
+        ) : (
+          <>
+            {/* week view, the main google calendar style grid */}
+            {calendarView === "week" && (
+              <div className="bg-white rounded-xl shadow-sm overflow-hidden">
+                {/* day headers */}
+                <div className="grid grid-cols-[60px_repeat(7,1fr)] border-b">
+                  <div className="border-r" /> {/* spacer for time col */}
+                  {weekDays.map((day) => (
+                    <div
+                      key={day.toISOString()}
+                      className={cn(
+                        "text-center py-3 border-r last:border-r-0",
+                        isToday(day) && "bg-blue-50"
+                      )}
+                    >
+                      <p className="text-xs text-gray-500 uppercase">{format(day, "EEE")}</p>
+                      <p className={cn(
+                        "text-lg font-semibold",
+                        isToday(day)
+                          ? "bg-blue-600 text-white rounded-full w-8 h-8 flex items-center justify-center mx-auto"
+                          : "text-gray-800"
+                      )}>
+                        {format(day, "d")}
+                      </p>
+                    </div>
+                  ))}
                 </div>
-                <div>
-                  <p className="font-medium"># Of Unique Students This Week:</p>
-                  <p>{getEnrollmentProgress().studentsThisWeek}</p>
-                </div>
-                <div>
-                  <p className="font-medium">Total Sessions This Week:</p>
-                  <p>{getSessionStatistics().totalSessions}</p>
-                </div>
-                <div>
-                  <p className="font-medium">Tutors Involved This Week:</p>
-                  <p>{getSessionStatistics().tutorsInvolved}</p>
+
+                {/* time grid - no scroll, all sessions visible */}
+                <div className="grid grid-cols-[60px_repeat(7,1fr)]">
+                  {HOURS.map((hour) => (
+                    <React.Fragment key={hour}>
+                      <div className="border-r border-b min-h-[36px] flex items-start justify-end pr-2 pt-1">
+                        <span className="text-[11px] text-gray-400">
+                          {hour === 0 ? "12:00 AM" : hour < 12 ? `${hour}:00 AM` : hour === 12 ? "12:00 PM" : `${hour - 12}:00 PM`}
+                        </span>
+                      </div>
+                      {weekDays.map((day) => {
+                        const daySessions = getValidSessionsForDay(day).filter(
+                          (s) => getSessionHour(s.date) === hour
+                        );
+                        return (
+                          <div
+                            key={`${day.toISOString()}-${hour}`}
+                            className={cn(
+                              "border-r border-b last:border-r-0 min-h-[36px] p-[2px] space-y-0.5",
+                              isToday(day) && "bg-blue-50/30"
+                            )}
+                          >
+                            {daySessions.map((session) => (
+                              <SessionCard key={session.id} session={session} />
+                            ))}
+                          </div>
+                        );
+                      })}
+                    </React.Fragment>
+                  ))}
                 </div>
               </div>
-            </CardContent>
-          </Card>
-        </div>
+            )}
 
+            {/* day view */}
+            {calendarView === "day" && (
+              <div className="bg-white rounded-xl shadow-sm overflow-hidden">
+                <div className="grid grid-cols-[60px_1fr]">
+                  {/* header */}
+                  <div className="border-r border-b" />
+                  <div className={cn("py-3 px-4 border-b", isToday(selectedDay) && "bg-blue-50")}>
+                    <p className="text-xs text-gray-500 uppercase">{format(selectedDay, "EEEE")}</p>
+                    <p className={cn(
+                      "text-2xl font-semibold",
+                      isToday(selectedDay) ? "text-blue-600" : "text-gray-800"
+                    )}>
+                      {format(selectedDay, "d")}
+                    </p>
+                  </div>
+                </div>
+                <div className="grid grid-cols-[60px_1fr]">
+                  {HOURS.map((hour) => {
+                    const daySessions = getValidSessionsForDay(selectedDay).filter(
+                      (s) => getSessionHour(s.date) === hour
+                    );
+                    return (
+                      <React.Fragment key={hour}>
+                        <div className="border-r border-b min-h-[36px] flex items-start justify-end pr-2 pt-1">
+                          <span className="text-[11px] text-gray-400">
+                            {hour === 0 ? "12:00 AM" : hour < 12 ? `${hour}:00 AM` : hour === 12 ? "12:00 PM" : `${hour - 12}:00 PM`}
+                          </span>
+                        </div>
+                        <div className={cn("border-b min-h-[36px] p-[2px] space-y-0.5", isToday(selectedDay) && "bg-blue-50/30")}>
+                          {daySessions.map((session) => (
+                            <SessionCard key={session.id} session={session} />
+                          ))}
+                        </div>
+                      </React.Fragment>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* month view */}
+            {calendarView === "month" && (
+              <div className="bg-white rounded-xl shadow-sm overflow-hidden">
+                {/* day of week headers */}
+                <div className="grid grid-cols-7 border-b">
+                  {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((d) => (
+                    <div key={d} className="text-center py-2 text-xs font-medium text-gray-500 uppercase border-r last:border-r-0">
+                      {d}
+                    </div>
+                  ))}
+                </div>
+                {/* calendar grid */}
+                <div className="grid grid-cols-7">
+                  {monthDays.map((day) => {
+                    const daySessions = getValidSessionsForDay(day);
+                    return (
+                      <div
+                        key={day.toISOString()}
+                        className={cn(
+                          "border-r border-b last:border-r-0 min-h-[100px] p-1",
+                          !isSameMonth(day, currentWeek) && "bg-gray-50 opacity-50",
+                          isToday(day) && "bg-blue-50"
+                        )}
+                      >
+                        <p className={cn(
+                          "text-xs font-medium mb-1",
+                          isToday(day)
+                            ? "bg-blue-600 text-white rounded-full w-5 h-5 flex items-center justify-center"
+                            : "text-gray-600"
+                        )}>
+                          {format(day, "d")}
+                        </p>
+                        <div className="space-y-0.5">
+                          {daySessions.map((session) => (
+                            <div
+                              key={session.id}
+                              onClick={() => {
+                                setSelectedSession(session);
+                                setIsModalOpen(true);
+                              }}
+                              className={cn(
+                                "text-[10px] px-1 py-0.5 rounded truncate cursor-pointer",
+                                session.status === "Complete"
+                                  ? "bg-green-100 text-green-800"
+                                  : session.status === "Cancelled"
+                                    ? "bg-red-100 text-red-800"
+                                    : "bg-blue-100 text-blue-800"
+                              )}
+                            >
+                              {session.tutor?.firstName} / {session.student?.firstName}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* session details modal, keeping all existing fields */}
         <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
           <DialogContent>
             <DialogHeader>
@@ -1022,24 +1110,14 @@ const Schedule = ({
                   <Label>Status</Label>
                   <Select
                     value={selectedSession?.status}
-                    onValueChange={(
-                      value: "Active" | "Complete" | "Cancelled",
-                    ) => {
+                    onValueChange={(value: "Active" | "Complete" | "Cancelled") => {
                       if (value && selectedSession) {
-                        const updatedSession = {
-                          ...selectedSession,
-                          status: value,
-                        };
-                        setSelectedSession(updatedSession);
+                        setSelectedSession({ ...selectedSession, status: value });
                       }
                     }}
                   >
                     <SelectTrigger>
-                      <SelectValue>
-                        {selectedSession?.status
-                          ? selectedSession.status
-                          : "Select status"}
-                      </SelectValue>
+                      <SelectValue>{selectedSession?.status || "Select status"}</SelectValue>
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="Active">Active</SelectItem>
@@ -1053,14 +1131,8 @@ const Schedule = ({
                   <Select
                     value={selectedSession.tutor?.id}
                     onValueChange={async (value) => {
-                      const selectedTutor =
-                        await getProfileWithProfileId(value);
-                      if (selectedTutor) {
-                        setSelectedSession({
-                          ...selectedSession,
-                          tutor: selectedTutor,
-                        });
-                      }
+                      const selectedTutor = await getProfileWithProfileId(value);
+                      if (selectedTutor) setSelectedSession({ ...selectedSession, tutor: selectedTutor });
                     }}
                   >
                     <SelectTrigger>
@@ -1071,13 +1143,12 @@ const Schedule = ({
                       </SelectValue>
                     </SelectTrigger>
                     <SelectContent>
-                      {tutors.map(
-                        (tutor) =>
-                          tutor.status !== "Inactive" && (
-                            <SelectItem key={tutor.id} value={tutor.id}>
-                              {tutor.firstName} {tutor.lastName}
-                            </SelectItem>
-                          ),
+                      {tutors.map((tutor) =>
+                        tutor.status !== "Inactive" && (
+                          <SelectItem key={tutor.id} value={tutor.id}>
+                            {tutor.firstName} {tutor.lastName}
+                          </SelectItem>
+                        )
                       )}
                     </SelectContent>
                   </Select>
@@ -1087,14 +1158,8 @@ const Schedule = ({
                   <Select
                     value={selectedSession.student?.id}
                     onValueChange={async (value) => {
-                      const selectedStudent =
-                        await getProfileWithProfileId(value);
-                      if (selectedStudent) {
-                        setSelectedSession({
-                          ...selectedSession,
-                          student: selectedStudent,
-                        });
-                      }
+                      const selectedStudent = await getProfileWithProfileId(value);
+                      if (selectedStudent) setSelectedSession({ ...selectedSession, student: selectedStudent });
                     }}
                   >
                     <SelectTrigger>
@@ -1105,13 +1170,12 @@ const Schedule = ({
                       </SelectValue>
                     </SelectTrigger>
                     <SelectContent>
-                      {students.map(
-                        (student) =>
-                          student.status !== "Inactive" && (
-                            <SelectItem key={student.id} value={student.id}>
-                              {student.firstName} {student.lastName}
-                            </SelectItem>
-                          ),
+                      {students.map((student) =>
+                        student.status !== "Inactive" && (
+                          <SelectItem key={student.id} value={student.id}>
+                            {student.firstName} {student.lastName}
+                          </SelectItem>
+                        )
                       )}
                     </SelectContent>
                   </Select>
@@ -1120,20 +1184,11 @@ const Schedule = ({
                   <Label>Date</Label>
                   <Input
                     type="datetime-local"
-                    defaultValue={format(
-                      parseISO(selectedSession.date),
-                      "yyyy-MM-dd'T'HH:mm",
-                    )}
+                    defaultValue={format(parseISO(selectedSession.date), "yyyy-MM-dd'T'HH:mm")}
                     onBlur={(e) => {
                       const scheduledDate = new Date(e.target.value);
-                      setSelectedSession({
-                        ...selectedSession,
-                        date: scheduledDate.toISOString(),
-                      });
-                      checkMeetingAvailabilites(
-                        selectedSession as Session,
-                        // scheduledDate
-                      );
+                      setSelectedSession({ ...selectedSession, date: scheduledDate.toISOString() });
+                      checkMeetingAvailabilites(selectedSession as Session);
                     }}
                   />
                 </div>
@@ -1141,35 +1196,20 @@ const Schedule = ({
                   <Label>Meeting</Label>
                   <Select
                     value={selectedSession?.meeting?.id || ""}
-                    onOpenChange={(open) => {}}
                     onValueChange={async (value) =>
-                      setSelectedSession({
-                        ...selectedSession,
-                        meeting: await getMeeting(value),
-                      })
+                      setSelectedSession({ ...selectedSession, meeting: await getMeeting(value) })
                     }
                   >
                     <SelectTrigger>
-                      <SelectValue>
-                        {selectedSession?.meeting?.name || "Select a meeting"}
-                      </SelectValue>
+                      <SelectValue>{selectedSession?.meeting?.name || "Select a meeting"}</SelectValue>
                     </SelectTrigger>
                     <SelectContent>
                       {meetings.map((meeting) => (
-                        <SelectItem
-                          key={meeting.id}
-                          value={meeting.id}
-                          className="flex items-center justify-between"
-                        >
-                          {/* <span>
-                          {meeting.name} - {meeting.id}
-                        </span> */}
+                        <SelectItem key={meeting.id} value={meeting.id} className="flex items-center justify-between">
                           <span>{meeting.name}</span>
                           <Circle
                             className={`w-2 h-2 ml-2 ${
-                              meetingAvailabilityMap[meeting.id]
-                                ? "text-green-500"
-                                : "text-red-500"
+                              meetingAvailabilityMap[meeting.id] ? "text-green-500" : "text-red-500"
                             } fill-current`}
                           />
                         </SelectItem>
@@ -1177,63 +1217,36 @@ const Schedule = ({
                     </SelectContent>
                   </Select>
                 </div>
-
                 <div>
-                  <Label className="text-right">Notes (Only viewable Admin Side)</Label> {/* admin only notes label */}
+                  <Label className="text-right">Notes (Only viewable Admin Side)</Label>
                   <Textarea
                     value={selectedSession?.summary}
-                    onChange={(e) =>
-                      setSelectedSession({
-                        ...selectedSession,
-                        summary: e.target.value,
-                      })
-                    }
-                  ></Textarea>
+                    onChange={(e) => setSelectedSession({ ...selectedSession, summary: e.target.value })}
+                  />
                 </div>
-
                 {(() => {
-                  const rawSef = (selectedSession as any)?.session_exit_form as
-                    | string
-                    | null
-                    | undefined; // pull sef string w null safe
-
-                  const sefFlags: string[] = []; // keep sef boxes tiny
-                  if ((selectedSession as any)?.isQuestionOrConcern)
-                    sefFlags.push("question/concern"); // show tutor box
-                  if ((selectedSession as any)?.isFirstSession)
-                    sefFlags.push("first session"); // show tutor box
-                  if (selectedSession.status === "Cancelled")
-                    sefFlags.push("cancelled"); // quick context
-
-                  let sefReasonText = rawSef ?? ""; // default to raw text
+                  const rawSef = (selectedSession as any)?.session_exit_form as string | null | undefined;
+                  const sefFlags: string[] = [];
+                  if ((selectedSession as any)?.isQuestionOrConcern) sefFlags.push("question/concern");
+                  if ((selectedSession as any)?.isFirstSession) sefFlags.push("first session");
+                  if (selectedSession.status === "Cancelled") sefFlags.push("cancelled");
+                  let sefReasonText = rawSef ?? "";
                   if (rawSef && rawSef.trim().startsWith("{")) {
                     try {
-                      const parsed = JSON.parse(rawSef) as any; // handle future sef json
-                      sefReasonText =
-                        parsed?.reason ??
-                        parsed?.notes ??
-                        parsed?.exitReason ??
-                        rawSef; // prefer explicit reason field
-                      const extraFlags =
-                        parsed?.boxes ?? parsed?.flags ?? parsed?.options; // try grab checkbox list
+                      const parsed = JSON.parse(rawSef) as any;
+                      sefReasonText = parsed?.reason ?? parsed?.notes ?? parsed?.exitReason ?? rawSef;
+                      const extraFlags = parsed?.boxes ?? parsed?.flags ?? parsed?.options;
                       if (Array.isArray(extraFlags)) {
-                        extraFlags
-                          .filter((x) => typeof x === "string")
-                          .forEach((x) => sefFlags.push(x)); // merge extra boxes
+                        extraFlags.filter((x) => typeof x === "string").forEach((x) => sefFlags.push(x));
                       }
                     } catch {
-                      // ignore parse fail, raw text fine
+                      // raw text fine
                     }
                   }
-
                   return (
                     <div>
-                      <Label>SEF Exit Reason</Label> {/* show sef reason */}
-                      <Textarea
-                        readOnly
-                        value={sefReasonText || ""}
-                        placeholder="no session exit form yet"
-                      />
+                      <Label>SEF Exit Reason</Label>
+                      <Textarea readOnly value={sefReasonText || ""} placeholder="no session exit form yet" />
                       <p className="text-xs text-gray-500 mt-1">
                         SEF boxes: {sefFlags.length ? sefFlags.join(", ") : "none"}
                       </p>
@@ -1241,10 +1254,7 @@ const Schedule = ({
                   );
                 })()}
                 <div className="flex flex-col gap-3">
-                  <Link
-                    href={`/dashboard/session/${selectedSession.id}/participation`}
-                    className="w-full"
-                  >
+                  <Link href={`/dashboard/session/${selectedSession.id}/participation`} className="w-full">
                     <Button variant="outline" className="w-full">
                       <Users className="mr-2 h-4 w-4" />
                       View Session Participation
@@ -1264,10 +1274,7 @@ const Schedule = ({
                         "Update Session"
                       )}
                     </Button>
-                    <Button
-                      variant="destructive"
-                      onClick={() => handleRemoveSession(selectedSession.id)}
-                    >
+                    <Button variant="destructive" onClick={() => handleRemoveSession(selectedSession.id)}>
                       Delete Session
                     </Button>
                   </div>

--- a/components/admin/ScheduleManagement.tsx
+++ b/components/admin/ScheduleManagement.tsx
@@ -20,6 +20,7 @@ import {
   isSameMonth,
   isToday,
   isValid,
+  startOfDay,
   previousDay,
   getDay,
 } from "date-fns";
@@ -681,7 +682,17 @@ const Schedule = ({
           ? "bg-green-50 border-l-green-500 text-green-900"
           : session.status === "Cancelled"
             ? "bg-red-50 border-l-red-500 text-red-900"
-            : "bg-blue-50 border-l-blue-500 text-blue-900"
+            : (() => {
+                try {
+                  const zonedDate = toZonedTime(parseISO(session.date), "America/New_York");
+                  const now = toZonedTime(new Date(), "America/New_York");
+                  return startOfDay(zonedDate) < startOfDay(now)
+                    ? "bg-orange-50 border-l-orange-400 text-orange-900"
+                    : "bg-blue-50 border-l-blue-500 text-blue-900";
+                } catch {
+                  return "bg-blue-50 border-l-blue-500 text-blue-900";
+                }
+              })()
       )}
     >
       <p className="font-medium truncate">

--- a/components/admin/SessionHistoryPanel.tsx
+++ b/components/admin/SessionHistoryPanel.tsx
@@ -138,18 +138,14 @@ export default function SessionHistoryPanel({
         )}
       </div>
 
-      <div className="flex items-center gap-3 mb-4 py-2 border-b border-gray-100 text-[12px] font-mono">
-        <span className="text-green-600 font-medium">{counts.completed}</span>
-        <span className="text-gray-400">completed</span>
-        <span className="text-gray-200">|</span>
-        <span className="text-red-500 font-medium">{counts.cancelled}</span>
-        <span className="text-gray-400">cancelled</span>
-        <span className="text-gray-200">|</span>
-        <span className="text-orange-500 font-medium">{counts.uncompleted}</span>
-        <span className="text-gray-400">uncompleted</span>
-        <span className="text-gray-200">|</span>
-        <span className="text-blue-500 font-medium">{counts.upcoming}</span>
-        <span className="text-gray-400">upcoming</span>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mb-4 py-2 border-b border-gray-100 text-[12px] font-mono">
+        <span><span className="text-green-600 font-medium">{counts.completed}</span> <span className="text-gray-400">completed</span></span>
+        <span className="text-gray-200">·</span>
+        <span><span className="text-red-500 font-medium">{counts.cancelled}</span> <span className="text-gray-400">cancelled</span></span>
+        <span className="text-gray-200">·</span>
+        <span><span className="text-orange-500 font-medium">{counts.uncompleted}</span> <span className="text-gray-400">uncompleted</span></span>
+        <span className="text-gray-200">·</span>
+        <span><span className="text-blue-500 font-medium">{counts.upcoming}</span> <span className="text-gray-400">upcoming</span></span>
       </div>
 
       <div className="text-[11px] text-gray-400 mb-2">

--- a/components/admin/SessionHistoryPanel.tsx
+++ b/components/admin/SessionHistoryPanel.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { format, parseISO } from "date-fns";
+import { toZonedTime } from "date-fns-tz";
+import { Session } from "@/types";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scrollarea";
+import { Loader2, CalendarDays, CheckCircle, XCircle, Clock } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { getSessionTimespan } from "@/lib/utils";
+
+interface SessionHistoryPanelProps {
+  sessions: Session[] | null;
+  loading: boolean;
+  title: string;
+  subtitle?: string;
+}
+
+const statusConfig: Record<string, { color: string; icon: React.ReactNode; bg: string }> = {
+  Complete: {
+    color: "text-green-700",
+    bg: "bg-green-50 border-green-200",
+    icon: <CheckCircle className="h-4 w-4 text-green-600" />,
+  },
+  Cancelled: {
+    color: "text-red-700",
+    bg: "bg-red-50 border-red-200",
+    icon: <XCircle className="h-4 w-4 text-red-600" />,
+  },
+  Active: {
+    color: "text-blue-700",
+    bg: "bg-blue-50 border-blue-200",
+    icon: <Clock className="h-4 w-4 text-blue-600" />,
+  },
+  Rescheduled: {
+    color: "text-amber-700",
+    bg: "bg-amber-50 border-amber-200",
+    icon: <CalendarDays className="h-4 w-4 text-amber-600" />,
+  },
+};
+
+const getStatusStyle = (status: string) => {
+  return statusConfig[status] || statusConfig["Active"];
+};
+
+export default function SessionHistoryPanel({
+  sessions,
+  loading,
+  title,
+  subtitle,
+}: SessionHistoryPanelProps) {
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-blue-500 mb-3" />
+        <p className="text-sm text-gray-500">Loading session history...</p>
+      </div>
+    );
+  }
+
+  if (!sessions || sessions.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12">
+        <CalendarDays className="h-8 w-8 text-gray-300 mb-3" />
+        <p className="text-sm text-gray-500">No sessions found</p>
+      </div>
+    );
+  }
+
+  const completedCount = sessions.filter((s) => s.status === "Complete").length;
+  const cancelledCount = sessions.filter((s) => s.status === "Cancelled").length;
+  const activeCount = sessions.filter((s) => s.status === "Active").length;
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="mb-4">
+        <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+        {subtitle && (
+          <p className="text-sm text-gray-500 mt-0.5">{subtitle}</p>
+        )}
+      </div>
+
+      <div className="flex gap-3 mb-4">
+        <div className="flex-1 rounded-lg bg-green-50 border border-green-200 p-3 text-center">
+          <p className="text-xl font-bold text-green-700">{completedCount}</p>
+          <p className="text-xs text-green-600">Completed</p>
+        </div>
+
+        <div className="flex-1 rounded-lg bg-red-50 border border-red-200 p-3 text-center">
+          <p className="text-xl font-bold text-red-700">{cancelledCount}</p>
+          <p className="text-xs text-red-600">Cancelled</p>
+        </div>
+
+        <div className="flex-1 rounded-lg bg-blue-50 border border-blue-200 p-3 text-center">
+          <p className="text-xl font-bold text-blue-700">{activeCount}</p>
+          <p className="text-xs text-blue-600">Upcoming</p>
+        </div>
+      </div>
+
+      <p className="text-xs text-gray-400 mb-2">
+        {sessions.length} total session{sessions.length !== 1 ? "s" : ""}
+      </p>
+
+      <ScrollArea className="flex-1 -mx-1 px-1">
+        <div className="space-y-2 pb-4">
+          {sessions.map((session) => {
+            const style = getStatusStyle(session.status);
+
+            let formattedDate = "";
+            let timespan = "";
+            try {
+              const zoned = toZonedTime(parseISO(session.date), "America/New_York");
+              formattedDate = format(zoned, "MMM d, yyyy");
+              timespan = getSessionTimespan(session.date, session.duration);
+            } catch {
+              formattedDate = "Invalid date";
+            }
+
+            return (
+              <div
+                key={session.id}
+                className={cn(
+                  "rounded-lg border p-3 transition-colors",
+                  style.bg,
+                )}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    {style.icon}
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-gray-900 truncate">
+                        {formattedDate}
+                      </p>
+                      <p className="text-xs text-gray-500">{timespan}</p>
+                    </div>
+                  </div>
+
+                  <Badge
+                    variant="outline"
+                    className={cn("text-[10px] shrink-0", style.color)}
+                  >
+                    {session.status}
+                  </Badge>
+                </div>
+
+                <div className="mt-2 grid grid-cols-2 gap-x-3 text-xs text-gray-600">
+                  <div>
+                    <span className="text-gray-400">Tutor: </span>
+                    {session.tutor?.firstName} {session.tutor?.lastName}
+                  </div>
+                  <div>
+                    <span className="text-gray-400">Student: </span>
+                    {session.student?.firstName} {session.student?.lastName}
+                  </div>
+                </div>
+
+                {session.summary && (
+                  <p className="mt-1.5 text-xs text-gray-500 line-clamp-2">
+                    {session.summary}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/components/admin/SessionHistoryPanel.tsx
+++ b/components/admin/SessionHistoryPanel.tsx
@@ -1,12 +1,20 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { format, parseISO } from "date-fns";
 import { toZonedTime } from "date-fns-tz";
 import { Session } from "@/types";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scrollarea";
-import { Loader2, CalendarDays, CheckCircle, XCircle, Clock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Loader2,
+  CalendarDays,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  ChevronDown,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getSessionTimespan } from "@/lib/utils";
 
@@ -17,31 +25,14 @@ interface SessionHistoryPanelProps {
   subtitle?: string;
 }
 
-const statusConfig: Record<string, { color: string; icon: React.ReactNode; bg: string }> = {
-  Complete: {
-    color: "text-green-700",
-    bg: "bg-green-50 border-green-200",
-    icon: <CheckCircle className="h-4 w-4 text-green-600" />,
-  },
-  Cancelled: {
-    color: "text-red-700",
-    bg: "bg-red-50 border-red-200",
-    icon: <XCircle className="h-4 w-4 text-red-600" />,
-  },
-  Active: {
-    color: "text-blue-700",
-    bg: "bg-blue-50 border-blue-200",
-    icon: <Clock className="h-4 w-4 text-blue-600" />,
-  },
-  Rescheduled: {
-    color: "text-amber-700",
-    bg: "bg-amber-50 border-amber-200",
-    icon: <CalendarDays className="h-4 w-4 text-amber-600" />,
-  },
-};
+const INITIAL_SHOW = 5;
+const LOAD_MORE_COUNT = 10;
 
-const getStatusStyle = (status: string) => {
-  return statusConfig[status] || statusConfig["Active"];
+const getStatusDot = (status: string) => {
+  if (status === "Complete") return "bg-emerald-500";
+  if (status === "Cancelled") return "bg-red-400";
+  if (status === "Rescheduled") return "bg-amber-400";
+  return "bg-slate-400";
 };
 
 export default function SessionHistoryPanel({
@@ -50,11 +41,14 @@ export default function SessionHistoryPanel({
   title,
   subtitle,
 }: SessionHistoryPanelProps) {
+  const [showAll, setShowAll] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(INITIAL_SHOW);
+
   if (loading) {
     return (
       <div className="flex flex-col items-center justify-center py-12">
-        <Loader2 className="h-6 w-6 animate-spin text-blue-500 mb-3" />
-        <p className="text-sm text-gray-500">Loading session history...</p>
+        <Loader2 className="h-5 w-5 animate-spin text-gray-400 mb-3" />
+        <p className="text-sm text-gray-400">loading...</p>
       </div>
     );
   }
@@ -62,8 +56,8 @@ export default function SessionHistoryPanel({
   if (!sessions || sessions.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-12">
-        <CalendarDays className="h-8 w-8 text-gray-300 mb-3" />
-        <p className="text-sm text-gray-500">No sessions found</p>
+        <CalendarDays className="h-6 w-6 text-gray-300 mb-2" />
+        <p className="text-sm text-gray-400">no sessions found</p>
       </div>
     );
   }
@@ -71,42 +65,66 @@ export default function SessionHistoryPanel({
   const completedCount = sessions.filter((s) => s.status === "Complete").length;
   const cancelledCount = sessions.filter((s) => s.status === "Cancelled").length;
   const activeCount = sessions.filter((s) => s.status === "Active").length;
+  const totalCount = sessions.length;
+
+  const displayedSessions = showAll
+    ? sessions.slice(0, visibleCount)
+    : sessions.slice(0, INITIAL_SHOW);
+
+  const hasMore = showAll
+    ? visibleCount < totalCount
+    : INITIAL_SHOW < totalCount;
+
+  const handleShowFullHistory = () => {
+    setShowAll(true);
+    setVisibleCount(Math.max(INITIAL_SHOW, LOAD_MORE_COUNT));
+  };
+
+  const handleLoadMore = () => {
+    setVisibleCount((prev) => Math.min(prev + LOAD_MORE_COUNT, totalCount));
+  };
 
   return (
     <div className="flex flex-col h-full">
-      <div className="mb-4">
-        <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+      <div className="mb-5">
+        <h3 className="text-base font-medium tracking-tight text-gray-800">
+          {title}
+        </h3>
         {subtitle && (
-          <p className="text-sm text-gray-500 mt-0.5">{subtitle}</p>
+          <p className="text-xs text-gray-400 mt-1">{subtitle}</p>
         )}
       </div>
 
-      <div className="flex gap-3 mb-4">
-        <div className="flex-1 rounded-lg bg-green-50 border border-green-200 p-3 text-center">
-          <p className="text-xl font-bold text-green-700">{completedCount}</p>
-          <p className="text-xs text-green-600">Completed</p>
+      <div className="flex gap-4 mb-5 text-xs">
+        <div className="flex items-center gap-1.5">
+          <div className="w-2 h-2 rounded-full bg-emerald-500" />
+          <span className="text-gray-600">
+            {completedCount} completed
+          </span>
         </div>
 
-        <div className="flex-1 rounded-lg bg-red-50 border border-red-200 p-3 text-center">
-          <p className="text-xl font-bold text-red-700">{cancelledCount}</p>
-          <p className="text-xs text-red-600">Cancelled</p>
+        <div className="flex items-center gap-1.5">
+          <div className="w-2 h-2 rounded-full bg-red-400" />
+          <span className="text-gray-600">
+            {cancelledCount} cancelled
+          </span>
         </div>
 
-        <div className="flex-1 rounded-lg bg-blue-50 border border-blue-200 p-3 text-center">
-          <p className="text-xl font-bold text-blue-700">{activeCount}</p>
-          <p className="text-xs text-blue-600">Upcoming</p>
+        <div className="flex items-center gap-1.5">
+          <div className="w-2 h-2 rounded-full bg-slate-400" />
+          <span className="text-gray-600">
+            {activeCount} upcoming
+          </span>
         </div>
       </div>
 
-      <p className="text-xs text-gray-400 mb-2">
-        {sessions.length} total session{sessions.length !== 1 ? "s" : ""}
-      </p>
+      <div className="text-[11px] text-gray-400 mb-3">
+        showing {displayedSessions.length} of {totalCount}
+      </div>
 
       <ScrollArea className="flex-1 -mx-1 px-1">
-        <div className="space-y-2 pb-4">
-          {sessions.map((session) => {
-            const style = getStatusStyle(session.status);
-
+        <div className="space-y-1.5 pb-4">
+          {displayedSessions.map((session) => {
             let formattedDate = "";
             let timespan = "";
             try {
@@ -120,50 +138,73 @@ export default function SessionHistoryPanel({
             return (
               <div
                 key={session.id}
-                className={cn(
-                  "rounded-lg border p-3 transition-colors",
-                  style.bg,
-                )}
+                className="flex items-center gap-3 rounded-md border border-gray-100 bg-white px-3 py-2.5 hover:bg-gray-50 transition-colors"
               >
-                <div className="flex items-start justify-between gap-2">
-                  <div className="flex items-center gap-2 min-w-0">
-                    {style.icon}
-                    <div className="min-w-0">
-                      <p className="text-sm font-medium text-gray-900 truncate">
-                        {formattedDate}
-                      </p>
-                      <p className="text-xs text-gray-500">{timespan}</p>
-                    </div>
+                <div className={cn("w-2 h-2 rounded-full shrink-0", getStatusDot(session.status))} />
+
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span className="text-sm text-gray-800 truncate">
+                      {session.tutor?.firstName} {session.tutor?.lastName}
+                      <span className="text-gray-300 mx-1">/</span>
+                      {session.student?.firstName} {session.student?.lastName}
+                    </span>
+                    <span className="text-[11px] text-gray-400 shrink-0 tabular-nums">
+                      {formattedDate}
+                    </span>
                   </div>
 
-                  <Badge
-                    variant="outline"
-                    className={cn("text-[10px] shrink-0", style.color)}
-                  >
-                    {session.status}
-                  </Badge>
+                  <div className="flex items-center gap-2 mt-0.5">
+                    <span className="text-[11px] text-gray-400">{timespan}</span>
+                    <span className="text-[11px] text-gray-300">·</span>
+                    <span className={cn(
+                      "text-[11px]",
+                      session.status === "Complete" && "text-emerald-600",
+                      session.status === "Cancelled" && "text-red-500",
+                      session.status === "Active" && "text-gray-500",
+                      session.status === "Rescheduled" && "text-amber-600",
+                    )}>
+                      {session.status.toLowerCase()}
+                    </span>
+                  </div>
+
+                  {session.summary && (
+                    <p className="text-[11px] text-gray-400 mt-1 truncate">
+                      {session.summary}
+                    </p>
+                  )}
                 </div>
-
-                <div className="mt-2 grid grid-cols-2 gap-x-3 text-xs text-gray-600">
-                  <div>
-                    <span className="text-gray-400">Tutor: </span>
-                    {session.tutor?.firstName} {session.tutor?.lastName}
-                  </div>
-                  <div>
-                    <span className="text-gray-400">Student: </span>
-                    {session.student?.firstName} {session.student?.lastName}
-                  </div>
-                </div>
-
-                {session.summary && (
-                  <p className="mt-1.5 text-xs text-gray-500 line-clamp-2">
-                    {session.summary}
-                  </p>
-                )}
               </div>
             );
           })}
         </div>
+
+        {!showAll && hasMore && (
+          <div className="pb-4">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleShowFullHistory}
+              className="w-full text-xs text-gray-500 hover:text-gray-700"
+            >
+              view full history ({totalCount} sessions)
+            </Button>
+          </div>
+        )}
+
+        {showAll && hasMore && (
+          <div className="pb-4">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleLoadMore}
+              className="w-full text-xs text-gray-500 hover:text-gray-700 gap-1"
+            >
+              <ChevronDown className="h-3 w-3" />
+              load more
+            </Button>
+          </div>
+        )}
       </ScrollArea>
     </div>
   );

--- a/components/admin/SessionHistoryPanel.tsx
+++ b/components/admin/SessionHistoryPanel.tsx
@@ -138,23 +138,18 @@ export default function SessionHistoryPanel({
         )}
       </div>
 
-      <div className="grid grid-cols-4 gap-2 mb-4">
-        <div className="flex flex-col items-center py-2 rounded-md bg-green-50 border border-green-100">
-          <span className="text-lg font-semibold text-green-700 leading-none">{counts.completed}</span>
-          <span className="text-[10px] text-green-600 mt-1">completed</span>
-        </div>
-        <div className="flex flex-col items-center py-2 rounded-md bg-red-50 border border-red-100">
-          <span className="text-lg font-semibold text-red-600 leading-none">{counts.cancelled}</span>
-          <span className="text-[10px] text-red-500 mt-1">cancelled</span>
-        </div>
-        <div className="flex flex-col items-center py-2 rounded-md bg-orange-50 border border-orange-100">
-          <span className="text-lg font-semibold text-orange-600 leading-none">{counts.uncompleted}</span>
-          <span className="text-[10px] text-orange-500 mt-1">uncompleted</span>
-        </div>
-        <div className="flex flex-col items-center py-2 rounded-md bg-blue-50 border border-blue-100">
-          <span className="text-lg font-semibold text-blue-600 leading-none">{counts.upcoming}</span>
-          <span className="text-[10px] text-blue-500 mt-1">upcoming</span>
-        </div>
+      <div className="flex items-center gap-3 mb-4 py-2 border-b border-gray-100 text-[12px] font-mono">
+        <span className="text-green-600 font-medium">{counts.completed}</span>
+        <span className="text-gray-400">completed</span>
+        <span className="text-gray-200">|</span>
+        <span className="text-red-500 font-medium">{counts.cancelled}</span>
+        <span className="text-gray-400">cancelled</span>
+        <span className="text-gray-200">|</span>
+        <span className="text-orange-500 font-medium">{counts.uncompleted}</span>
+        <span className="text-gray-400">uncompleted</span>
+        <span className="text-gray-200">|</span>
+        <span className="text-blue-500 font-medium">{counts.upcoming}</span>
+        <span className="text-gray-400">upcoming</span>
       </div>
 
       <div className="text-[11px] text-gray-400 mb-2">

--- a/components/admin/SessionHistoryPanel.tsx
+++ b/components/admin/SessionHistoryPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useState } from "react";
-import { format, parseISO } from "date-fns";
+import React, { useState, useMemo } from "react";
+import { format, parseISO, isPast, startOfDay } from "date-fns";
 import { toZonedTime } from "date-fns-tz";
 import { Session } from "@/types";
 import { Badge } from "@/components/ui/badge";
@@ -10,9 +10,6 @@ import { Button } from "@/components/ui/button";
 import {
   Loader2,
   CalendarDays,
-  CheckCircle2,
-  XCircle,
-  Clock,
   ChevronDown,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -27,12 +24,50 @@ interface SessionHistoryPanelProps {
 
 const INITIAL_SHOW = 5;
 const LOAD_MORE_COUNT = 10;
+const TZ = "America/New_York";
 
-const getStatusDot = (status: string) => {
-  if (status === "Complete") return "bg-emerald-500";
-  if (status === "Cancelled") return "bg-red-400";
-  if (status === "Rescheduled") return "bg-amber-400";
-  return "bg-slate-400";
+type ResolvedStatus = "Complete" | "Cancelled" | "Rescheduled" | "Uncompleted" | "Upcoming";
+
+function resolveStatus(session: Session): ResolvedStatus {
+  if (session.status === "Complete") return "Complete";
+  if (session.status === "Cancelled") return "Cancelled";
+  if (session.status === "Rescheduled") return "Rescheduled";
+
+  try {
+    const zonedDate = toZonedTime(parseISO(session.date), TZ);
+    const now = toZonedTime(new Date(), TZ);
+    return startOfDay(zonedDate) < startOfDay(now) ? "Uncompleted" : "Upcoming";
+  } catch {
+    return "Upcoming";
+  }
+}
+
+const statusStyles: Record<ResolvedStatus, { card: string; badge: string; badgeText: string }> = {
+  Complete: {
+    card: "border-l-green-500 bg-green-50/40",
+    badge: "bg-green-100 text-green-700 border-green-200",
+    badgeText: "completed",
+  },
+  Cancelled: {
+    card: "border-l-red-400 bg-red-50/40",
+    badge: "bg-red-100 text-red-700 border-red-200",
+    badgeText: "cancelled",
+  },
+  Rescheduled: {
+    card: "border-l-amber-400 bg-amber-50/40",
+    badge: "bg-amber-100 text-amber-700 border-amber-200",
+    badgeText: "rescheduled",
+  },
+  Uncompleted: {
+    card: "border-l-orange-400 bg-orange-50/40",
+    badge: "bg-orange-100 text-orange-700 border-orange-200",
+    badgeText: "uncompleted",
+  },
+  Upcoming: {
+    card: "border-l-blue-400 bg-blue-50/40",
+    badge: "bg-blue-100 text-blue-700 border-blue-200",
+    badgeText: "upcoming",
+  },
 };
 
 export default function SessionHistoryPanel({
@@ -43,6 +78,19 @@ export default function SessionHistoryPanel({
 }: SessionHistoryPanelProps) {
   const [showAll, setShowAll] = useState(false);
   const [visibleCount, setVisibleCount] = useState(INITIAL_SHOW);
+
+  const counts = useMemo(() => {
+    if (!sessions) return { completed: 0, cancelled: 0, uncompleted: 0, upcoming: 0, total: 0 };
+    let completed = 0, cancelled = 0, uncompleted = 0, upcoming = 0;
+    for (const s of sessions) {
+      const rs = resolveStatus(s);
+      if (rs === "Complete") completed++;
+      else if (rs === "Cancelled") cancelled++;
+      else if (rs === "Uncompleted") uncompleted++;
+      else if (rs === "Upcoming") upcoming++;
+    }
+    return { completed, cancelled, uncompleted, upcoming, total: sessions.length };
+  }, [sessions]);
 
   if (loading) {
     return (
@@ -62,18 +110,13 @@ export default function SessionHistoryPanel({
     );
   }
 
-  const completedCount = sessions.filter((s) => s.status === "Complete").length;
-  const cancelledCount = sessions.filter((s) => s.status === "Cancelled").length;
-  const activeCount = sessions.filter((s) => s.status === "Active").length;
-  const totalCount = sessions.length;
-
   const displayedSessions = showAll
     ? sessions.slice(0, visibleCount)
     : sessions.slice(0, INITIAL_SHOW);
 
   const hasMore = showAll
-    ? visibleCount < totalCount
-    : INITIAL_SHOW < totalCount;
+    ? visibleCount < counts.total
+    : INITIAL_SHOW < counts.total;
 
   const handleShowFullHistory = () => {
     setShowAll(true);
@@ -81,12 +124,12 @@ export default function SessionHistoryPanel({
   };
 
   const handleLoadMore = () => {
-    setVisibleCount((prev) => Math.min(prev + LOAD_MORE_COUNT, totalCount));
+    setVisibleCount((prev) => Math.min(prev + LOAD_MORE_COUNT, counts.total));
   };
 
   return (
     <div className="flex flex-col h-full">
-      <div className="mb-5">
+      <div className="mb-4">
         <h3 className="text-base font-medium tracking-tight text-gray-800">
           {title}
         </h3>
@@ -95,40 +138,39 @@ export default function SessionHistoryPanel({
         )}
       </div>
 
-      <div className="flex gap-4 mb-5 text-xs">
-        <div className="flex items-center gap-1.5">
-          <div className="w-2 h-2 rounded-full bg-emerald-500" />
-          <span className="text-gray-600">
-            {completedCount} completed
-          </span>
+      <div className="grid grid-cols-4 gap-2 mb-4">
+        <div className="flex flex-col items-center py-2 rounded-md bg-green-50 border border-green-100">
+          <span className="text-lg font-semibold text-green-700 leading-none">{counts.completed}</span>
+          <span className="text-[10px] text-green-600 mt-1">completed</span>
         </div>
-
-        <div className="flex items-center gap-1.5">
-          <div className="w-2 h-2 rounded-full bg-red-400" />
-          <span className="text-gray-600">
-            {cancelledCount} cancelled
-          </span>
+        <div className="flex flex-col items-center py-2 rounded-md bg-red-50 border border-red-100">
+          <span className="text-lg font-semibold text-red-600 leading-none">{counts.cancelled}</span>
+          <span className="text-[10px] text-red-500 mt-1">cancelled</span>
         </div>
-
-        <div className="flex items-center gap-1.5">
-          <div className="w-2 h-2 rounded-full bg-slate-400" />
-          <span className="text-gray-600">
-            {activeCount} upcoming
-          </span>
+        <div className="flex flex-col items-center py-2 rounded-md bg-orange-50 border border-orange-100">
+          <span className="text-lg font-semibold text-orange-600 leading-none">{counts.uncompleted}</span>
+          <span className="text-[10px] text-orange-500 mt-1">uncompleted</span>
+        </div>
+        <div className="flex flex-col items-center py-2 rounded-md bg-blue-50 border border-blue-100">
+          <span className="text-lg font-semibold text-blue-600 leading-none">{counts.upcoming}</span>
+          <span className="text-[10px] text-blue-500 mt-1">upcoming</span>
         </div>
       </div>
 
-      <div className="text-[11px] text-gray-400 mb-3">
-        showing {displayedSessions.length} of {totalCount}
+      <div className="text-[11px] text-gray-400 mb-2">
+        showing {displayedSessions.length} of {counts.total}
       </div>
 
       <ScrollArea className="flex-1 -mx-1 px-1">
         <div className="space-y-1.5 pb-4">
           {displayedSessions.map((session) => {
+            const resolved = resolveStatus(session);
+            const style = statusStyles[resolved];
+
             let formattedDate = "";
             let timespan = "";
             try {
-              const zoned = toZonedTime(parseISO(session.date), "America/New_York");
+              const zoned = toZonedTime(parseISO(session.date), TZ);
               formattedDate = format(zoned, "MMM d, yyyy");
               timespan = getSessionTimespan(session.date, session.duration);
             } catch {
@@ -138,42 +180,36 @@ export default function SessionHistoryPanel({
             return (
               <div
                 key={session.id}
-                className="flex items-center gap-3 rounded-md border border-gray-100 bg-white px-3 py-2.5 hover:bg-gray-50 transition-colors"
+                className={cn(
+                  "rounded-md border border-gray-100 border-l-[3px] px-3 py-2.5 transition-colors",
+                  style.card,
+                )}
               >
-                <div className={cn("w-2 h-2 rounded-full shrink-0", getStatusDot(session.status))} />
-
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-baseline justify-between gap-2">
-                    <span className="text-sm text-gray-800 truncate">
-                      {session.tutor?.firstName} {session.tutor?.lastName}
-                      <span className="text-gray-300 mx-1">/</span>
-                      {session.student?.firstName} {session.student?.lastName}
-                    </span>
-                    <span className="text-[11px] text-gray-400 shrink-0 tabular-nums">
-                      {formattedDate}
-                    </span>
-                  </div>
-
-                  <div className="flex items-center gap-2 mt-0.5">
-                    <span className="text-[11px] text-gray-400">{timespan}</span>
-                    <span className="text-[11px] text-gray-300">·</span>
-                    <span className={cn(
-                      "text-[11px]",
-                      session.status === "Complete" && "text-emerald-600",
-                      session.status === "Cancelled" && "text-red-500",
-                      session.status === "Active" && "text-gray-500",
-                      session.status === "Rescheduled" && "text-amber-600",
-                    )}>
-                      {session.status.toLowerCase()}
-                    </span>
-                  </div>
-
-                  {session.summary && (
-                    <p className="text-[11px] text-gray-400 mt-1 truncate">
-                      {session.summary}
-                    </p>
-                  )}
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-sm text-gray-800 truncate">
+                    {session.tutor?.firstName} {session.tutor?.lastName}
+                    <span className="text-gray-300 mx-1.5">/</span>
+                    {session.student?.firstName} {session.student?.lastName}
+                  </span>
+                  <Badge
+                    variant="outline"
+                    className={cn("text-[10px] font-normal shrink-0 py-0 px-1.5", style.badge)}
+                  >
+                    {style.badgeText}
+                  </Badge>
                 </div>
+
+                <div className="flex items-center gap-2 mt-1 text-[11px] text-gray-500">
+                  <span className="tabular-nums">{formattedDate}</span>
+                  <span className="text-gray-300">·</span>
+                  <span>{timespan}</span>
+                </div>
+
+                {session.summary && (
+                  <p className="text-[11px] text-gray-400 mt-1 truncate">
+                    {session.summary}
+                  </p>
+                )}
               </div>
             );
           })}
@@ -187,7 +223,7 @@ export default function SessionHistoryPanel({
               onClick={handleShowFullHistory}
               className="w-full text-xs text-gray-500 hover:text-gray-700"
             >
-              view full history ({totalCount} sessions)
+              view full history ({counts.total} sessions)
             </Button>
           </div>
         )}

--- a/components/admin/StudentList.tsx
+++ b/components/admin/StudentList.tsx
@@ -723,7 +723,7 @@ const StudentList = ({ initialStudents }: any) =>
             <SessionHistoryPanel
               sessions={historySessions}
               loading={historyLoading}
-              title="Student History"
+              title="Student History - Comes from Tutor Filling SEF"
               subtitle={
                 historyStudent
                   ? `${historyStudent.firstName} ${historyStudent.lastName}`

--- a/components/admin/StudentList.tsx
+++ b/components/admin/StudentList.tsx
@@ -54,7 +54,7 @@ import { editProfile } from "@/lib/actions/profile.server.actions"
 import { deleteUser } from "@/lib/actions/auth.server.actions";
 import { addUser } from "@/lib/actions/auth.actions";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import { Profile } from "@/types";
+import { Profile, Session } from "@/types";
 import {
   Dialog,
   DialogContent,
@@ -71,6 +71,10 @@ import AddStudentForm from "./components/AddStudentForm";
 import DeleteStudentForm from "./components/DeleteStudentForm";
 import EditStudentForm from "./components/EditStudentForm";
 import { UserAvailabilities } from "../ui/UserAvailabilities";
+import { getStudentSessions } from "@/lib/actions/session.actions";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet";
+import SessionHistoryPanel from "@/components/admin/SessionHistoryPanel";
+import { History } from "lucide-react";
 
 const getOrdinalSuffix = (num: number): string => {
   if (num === 1) return "st";
@@ -139,6 +143,31 @@ const StudentList = ({ initialStudents }: any) =>
     const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
     const [addingStudent, setAddingStudent] = useState(false);
+
+    const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+    const [historyStudent, setHistoryStudent] = useState<Profile | null>(null);
+    const [historySessions, setHistorySessions] = useState<Session[] | null>(null);
+    const [historyLoading, setHistoryLoading] = useState(false);
+
+    const handleViewStudentHistory = async (student: Profile) => {
+      setHistoryStudent(student);
+      setIsHistoryOpen(true);
+      setHistoryLoading(true);
+      setHistorySessions(null);
+
+      try {
+        const sessions = await getStudentSessions(
+          student.id,
+          { orderBy: "date", ascending: false },
+        );
+        setHistorySessions(sessions);
+      } catch (err) {
+        console.error("Failed to fetch student session history", err);
+        toast.error("Failed to load session history");
+      } finally {
+        setHistoryLoading(false);
+      }
+    };
 
     const getStudentData = async () => {
       try {
@@ -553,6 +582,7 @@ const StudentList = ({ initialStudents }: any) =>
               <TableHead>Parent Email</TableHead>
               <TableHead>Parent Phone</TableHead>
               <TableHead>Actions</TableHead>
+              <TableHead>History</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -612,6 +642,15 @@ const StudentList = ({ initialStudents }: any) =>
                       </AlertDialogFooter>
                     </AlertDialogContent>
                   </AlertDialog>
+                </TableCell>
+                <TableCell>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleViewStudentHistory(student)}
+                  >
+                    <History className="h-4 w-4" />
+                  </Button>
                 </TableCell>
               </TableRow>
             ))}
@@ -674,6 +713,25 @@ const StudentList = ({ initialStudents }: any) =>
             </div>
           </div>
         </div>
+
+        <Sheet open={isHistoryOpen} onOpenChange={setIsHistoryOpen}>
+          <SheetContent side="right" className="w-[420px] sm:max-w-[420px]">
+            <SheetHeader className="sr-only">
+              <SheetTitle>Student Session History</SheetTitle>
+              <SheetDescription>Session history for this student</SheetDescription>
+            </SheetHeader>
+            <SessionHistoryPanel
+              sessions={historySessions}
+              loading={historyLoading}
+              title="Student History"
+              subtitle={
+                historyStudent
+                  ? `${historyStudent.firstName} ${historyStudent.lastName}`
+                  : ""
+              }
+            />
+          </SheetContent>
+        </Sheet>
 
         <Toaster />
       </>

--- a/components/admin/TutorList.tsx
+++ b/components/admin/TutorList.tsx
@@ -82,6 +82,9 @@ import EditTutorForm from "./components/EditTutorForm";
 import { Turret_Road } from "next/font/google";
 import { capitalizeFirstLetter } from "@/lib/utils";
 import { UserAvailabilities } from "../ui/UserAvailabilities";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet";
+import SessionHistoryPanel from "@/components/admin/SessionHistoryPanel";
+import { History } from "lucide-react";
 
 const TutorList = ({ initialTutors }: any) => {
   const supabase = createClientComponentClient();
@@ -127,6 +130,35 @@ const TutorList = ({ initialTutors }: any) => {
     {},
   );
   const [addingTutor, setAddingTutor] = useState(false);
+
+  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+  const [historyTutor, setHistoryTutor] = useState<Profile | null>(null);
+  const [historySessions, setHistorySessions] = useState<Session[] | null>(null);
+  const [historyLoading, setHistoryLoading] = useState(false);
+
+  const handleViewTutorHistory = async (tutor: Profile) => {
+    setHistoryTutor(tutor);
+    setIsHistoryOpen(true);
+    setHistoryLoading(true);
+    setHistorySessions(null);
+
+    try {
+      const sessions = await getTutorSessions(
+        tutor.id,
+        undefined,
+        undefined,
+        undefined,
+        "date",
+        false,
+      );
+      setHistorySessions(sessions);
+    } catch (err) {
+      console.error("Failed to fetch tutor session history", err);
+      toast.error("Failed to load session history");
+    } finally {
+      setHistoryLoading(false);
+    }
+  };
 
   const getTutorData = async () => {
     try {
@@ -422,6 +454,7 @@ const TutorList = ({ initialTutors }: any) => {
             <TableHead>Phone Number</TableHead>
             <TableHead>Gender</TableHead>
             <TableHead>Actions</TableHead>
+            <TableHead>History</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -484,6 +517,15 @@ const TutorList = ({ initialTutors }: any) => {
                   </AlertDialogContent>
                 </AlertDialog>
               </TableCell>
+              <TableCell>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleViewTutorHistory(tutor)}
+                >
+                  <History className="h-4 w-4" />
+                </Button>
+              </TableCell>
             </TableRow>
           ))}
         </TableBody>
@@ -544,6 +586,25 @@ const TutorList = ({ initialTutors }: any) => {
           </div>
         </div>
       </div>
+      <Sheet open={isHistoryOpen} onOpenChange={setIsHistoryOpen}>
+        <SheetContent side="right" className="w-[420px] sm:max-w-[420px]">
+          <SheetHeader className="sr-only">
+            <SheetTitle>Tutor Session History</SheetTitle>
+            <SheetDescription>Session history for this tutor</SheetDescription>
+          </SheetHeader>
+          <SessionHistoryPanel
+            sessions={historySessions}
+            loading={historyLoading}
+            title="Tutor History"
+            subtitle={
+              historyTutor
+                ? `${historyTutor.firstName} ${historyTutor.lastName}`
+                : ""
+            }
+          />
+        </SheetContent>
+      </Sheet>
+
       <Toaster />
     </>
   );

--- a/lib/actions/session.actions.ts
+++ b/lib/actions/session.actions.ts
@@ -477,3 +477,46 @@ export async function getSessionTimePassed(sessionId: string): Promise<number> {
   const diff = now.getTime() - sessionDate.getTime();
   return diff;
 }
+
+export async function getSessionsByEnrollmentId(
+  enrollmentId: string,
+): Promise<Session[]> {
+  const { data, error } = await supabase
+    .from(Table.Sessions)
+    .select(
+      `
+      *,
+      student:Profiles!student_id(*),
+      tutor:Profiles!tutor_id(*),
+      meeting:Meetings!meeting_id(*)
+    `,
+    )
+    .eq("enrollment_id", enrollmentId)
+    .order("date", { ascending: false });
+
+  if (error) {
+    console.error("Error fetching sessions by enrollment:", error.message);
+    throw error;
+  }
+
+  const sessions: Session[] = data
+    .filter((s: any) => s.student && s.tutor)
+    .map((session: any) => ({
+      id: session.id,
+      enrollmentId: session.enrollment_id,
+      createdAt: session.created_at,
+      environment: session.environment,
+      date: session.date,
+      summary: session.summary,
+      meeting: session.meeting ? tableToInterfaceMeetings(session.meeting) : null,
+      student: tableToInterfaceProfiles(session.student),
+      tutor: tableToInterfaceProfiles(session.tutor),
+      status: session.status,
+      session_exit_form: session.session_exit_form,
+      isQuestionOrConcern: Boolean(session.is_question_or_concern),
+      isFirstSession: Boolean(session.is_first_session),
+      duration: session.duration,
+    }));
+
+  return sessions;
+}


### PR DESCRIPTION
Adds a shared session history panel that gets integrated into the admin dashboard views for enrollments, tutors, and students. shows a complete breakdown of sessions with color-coded status indicators and pagination for browsing through history.

new shared component that displays session history with inline stats counters showing completed, cancelled, uncompleted, and upcoming counts. session cards are color-coded with green for complete, red for cancelled, orange for uncompleted, and blue for upcoming. includes a "view full history" button that expands to show all sessions within the panel, and a "load more" pagination that shows 5 initially then loads 10 at a time when expanded. each session card shows tutor and student names, date, timespan, status badge, and summary.

added a new server action to fetch sessions filtered by enrollment id.

enrollments management now has a history button in the table that opens the history panel titled "SEF Enrollment History" showing all sessions for that enrollment. tutor list has a history button that opens the panel for that tutor's sessions. student list has a history button that opens the panel titled "Student History - Comes from Tutor Filling SEF".

calendar now correctly distinguishes between uncompleted and upcoming active sessions. active sessions with a date in the past show as orange (uncompleted) instead of blue. upcoming sessions stay blue. this uses timezone-aware date comparison in America/New_York.

also merged in the google calendar admin improvements from the googleCalAdmin branch which includes calendar view enhancements.
closes #507 